### PR TITLE
feat: add parser crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,3 +5,7 @@ version = 3
 [[package]]
 name = "rede"
 version = "0.1.0"
+
+[[package]]
+name = "rede_parser"
+version = "0.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
-    "bin"
+    "bin",
+    "parser"
 ]
 resolver = "2"
 

--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -1,14 +1,16 @@
 [package]
 name = "rede"
 version = "0.1.0"
+
 edition.workspace = true
 
 authors.workspace = true
+homepage.workspace = true
+license.workspace = true
+repository.workspace = true
+
 categories = [ "command-line-utilities" , "development-tools", "web-programming::http-client"]
 description = "CLI tool to run and configure suites of HTTP requests defined in readable files"
 documentation = "TODO"
 keywords = [ "cli", "http", "api", "request" ]
-homepage.workspace = true
-license.workspace = true
 readme = "../README.md"
-repository.workspace = true

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "rede_parser"
+version = "0.1.0"
+edition.workspace = true
+
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+
+categories = [ "parser-implementations", "development-tools" ]
+description = "Parser in charge of modeling Rede's files"
+documentation = "TODO"
+keywords = [ "parser", "rede", "toml", "http" ]
+readme = "./README.md"
+
+[dependencies]

--- a/parser/README.md
+++ b/parser/README.md
@@ -1,0 +1,5 @@
+# Rede Parser
+
+Library crate to receive the content of Rede's files and generate the requests or environments
+to use in the command-line binary. It can be used on its own to implement Rede's format in other
+projects or implementations.

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -1,0 +1,14 @@
+pub fn add(left: usize, right: usize) -> usize {
+    left + right
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_works() {
+        let result = add(2, 2);
+        assert_eq!(result, 4);
+    }
+}


### PR DESCRIPTION
Adds a new `rede_parser` create to the workspace, allowing to use it as the library for the Rede Parser.