### PR TITLE
feat: redirect options

### DIFF
--- a/bin/src/commands/reqwest.rs
+++ b/bin/src/commands/reqwest.rs
@@ -1,21 +1,30 @@
 use crate::commands::run::RequestArgs;
 use rede_parser::Request;
-use reqwest::{ClientBuilder, Request as Reqwest, RequestBuilder, Url};
+use reqwest::redirect::Policy;
+use reqwest::{Client, ClientBuilder, Request as Reqwest, RequestBuilder, Url};
 
 use crate::errors::RequestError;
 
 pub async fn send(req: Request, args: RequestArgs) -> Result<String, RequestError<reqwest::Error>> {
     let url = Url::parse(&req.url).map_err(|e| RequestError::invalid_url(&req.url, e))?;
 
+    let client = build_client(&args)?;
+    let reqwest = Reqwest::new(req.method, url);
+    let builder = RequestBuilder::from_parts(client, reqwest).version(req.http_version);
+    // todo handle send errors
+    // todo handle text errors
+    Ok(builder.send().await?.text().await?)
+}
+
+fn build_client(args: &RequestArgs) -> Result<Client, reqwest::Error> {
     let mut client = ClientBuilder::new();
     if let Some(timeout) = args.timeout {
         client = client.timeout(timeout);
     }
-
-    let reqwest = Reqwest::new(req.method, url);
-    // todo handle build errors
-    let builder = RequestBuilder::from_parts(client.build()?, reqwest).version(req.http_version);
-    // todo handle send errors
-    // todo handle text errors
-    Ok(builder.send().await?.text().await?)
+    client = match (args.no_redirect, args.max_redirects) {
+        (true, _) => client.redirect(Policy::none()),
+        (false, Some(val)) => client.redirect(Policy::limited(val)),
+        _ => client,
+    };
+    client.build()
 }

--- a/bin/src/commands/run.rs
+++ b/bin/src/commands/run.rs
@@ -14,9 +14,15 @@ pub struct Command {
     /// Request file to execute
     #[arg(default_value = "-")]
     request: String,
-    /// Timeout, in a string like \[0-9]+(ns|us|ms|\[smhdwy], for example "3m"
-    #[arg(short, long)]
+    /// Timeout, in a string like [0-9]+(ns|us|ms|[smhdwy], for example "3m"
+    #[arg(long)]
     timeout: Option<String>,
+    /// Disallows auto-redirection
+    #[arg(long)]
+    no_redirect: bool,
+    /// Maximum number of redirects allowed, by default 10.
+    #[arg(long)]
+    max_redirects: Option<usize>,
 }
 
 impl Command {
@@ -36,6 +42,8 @@ impl Command {
 
 pub struct RequestArgs {
     pub timeout: Option<Duration>,
+    pub no_redirect: bool,
+    pub max_redirects: Option<usize>,
 }
 
 impl TryFrom<&Command> for RequestArgs {
@@ -59,6 +67,10 @@ impl TryFrom<&Command> for RequestArgs {
                 .with_source_code(t.to_owned())
             })?;
 
-        Ok(RequestArgs { timeout })
+        Ok(RequestArgs {
+            timeout,
+            no_redirect: value.no_redirect,
+            max_redirects: value.max_redirects,
+        })
     }
 }

--- a/bin/tests/inputs/redirect_loop.toml
+++ b/bin/tests/inputs/redirect_loop.toml
@@ -1,0 +1,1 @@
+http.url = "http://localhost:8080/api/redirect_loop"

--- a/bin/tests/run.rs
+++ b/bin/tests/run.rs
@@ -1,4 +1,5 @@
 use assert_cmd::Command;
+use predicates::boolean::PredicateBooleanExt;
 use predicates::prelude::predicate::str::contains;
 
 // Set of integration tests for `rede run`, they are all ignored to run them only manually.
@@ -49,7 +50,8 @@ macro_rules! test_error {
 }
 
 test_request!(get_simple -> contains(r#"{"hello":"world"}"#));
-test_request!(http_version -> contains(r#"{"http_version":"HTTP/1.0"}"#));
+test_request!(http_version -> contains(r#""http_version":"HTTP/1.0""#));
+// todo -no-redirect, requires --verbose
 
 test_error!(invalid_url -> contains("invalid url"));
 test_error!(failed_connection -> contains("failed connection"));
@@ -57,3 +59,4 @@ test_error!(bad_url_scheme -> contains("failed request building"));
 test_error!(timeout<>, "--timeout", "0s" -> contains("timeout"));
 
 test_error!(#[ignore] unsupported_http_version -> contains("wrong http version"));
+test_error!(#[ignore] redirect_loop, "--max-redirects", "5" -> contains("redirect"));


### PR DESCRIPTION
Adds two new options to `rede run` to allow control of redirections:
- `--no-redirects` is a flag to disable automatic redirection.
- `--max-redirects` to set the number of maximum allowed redirects