### PR TITLE
feat: support headers

### DIFF
--- a/bin/src/commands/reqwest.rs
+++ b/bin/src/commands/reqwest.rs
@@ -10,7 +10,9 @@ pub async fn send(req: Request, args: RequestArgs) -> Result<String, RequestErro
 
     let client = build_client(&args)?;
     let reqwest = Reqwest::new(req.method, url);
-    let builder = RequestBuilder::from_parts(client, reqwest).version(req.http_version);
+    let builder = RequestBuilder::from_parts(client, reqwest)
+        .version(req.http_version)
+        .headers(req.headers);
     // todo handle send errors
     // todo handle text errors
     Ok(builder.send().await?.text().await?)

--- a/bin/tests/inputs/headers.toml
+++ b/bin/tests/inputs/headers.toml
@@ -1,0 +1,8 @@
+[http]
+method = "GET"
+url = "http://localhost:8080/api/request"
+
+[headers]
+Content-Type = "application/json"
+Accept = "application/json"
+User-Agent = "rede"

--- a/bin/tests/run.rs
+++ b/bin/tests/run.rs
@@ -51,6 +51,7 @@ macro_rules! test_error {
 
 test_request!(get_simple -> contains(r#"{"hello":"world"}"#));
 test_request!(http_version -> contains(r#""http_version":"HTTP/1.0""#));
+test_request!(headers -> contains(r#""content-type":"application/json""#).and(contains(r#""num_headers":4"#)));
 // todo -no-redirect, requires --verbose
 
 test_error!(invalid_url -> contains("invalid url"));


### PR DESCRIPTION
Allows `rede run` to send headers in the requests 