### PR TITLE
feat: support query params on rede run

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -906,7 +906,7 @@ dependencies = [
  "log",
  "miette",
  "predicates",
- "rede_parser 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rede_parser 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest",
  "thiserror",
  "tokio",
@@ -915,7 +915,7 @@ dependencies = [
 
 [[package]]
 name = "rede_parser"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "http",
  "http-serde",
@@ -927,9 +927,9 @@ dependencies = [
 
 [[package]]
 name = "rede_parser"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb285e928bdb8a6968e3b1aa6584f25c390f19d19f60fa4ecfff0ffec8f49474"
+checksum = "ab99eb3b8479b5aa9b21b9db147254434351a853fcbd9d674b337046ecb4ed0d"
 dependencies = [
  "http",
  "http-serde",

--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -16,13 +16,15 @@ keywords = [ "cli", "http", "api", "request" ]
 readme = "../README.md"
 
 [dependencies]
-rede_parser = "0.1.1"
+rede_parser = "0.1.2"
+
 log.workspace = true
 thiserror.workspace = true
-env_logger = "0.11.3"
+
 clap = { version = "4.5.4", features = ["derive"] }
 colored = "2.1.0"
 duration-str = { version = "0.7.1", default-features = false }
+env_logger = "0.11.3"
 miette = { version = "7.2.0", features = ["fancy"] }
 reqwest = "0.12"
 tokio = { version = "1.37.0", features = ["tokio-macros"] }

--- a/bin/src/commands/reqwest.rs
+++ b/bin/src/commands/reqwest.rs
@@ -12,7 +12,8 @@ pub async fn send(req: Request, args: RequestArgs) -> Result<String, RequestErro
     let reqwest = Reqwest::new(req.method, url);
     let builder = RequestBuilder::from_parts(client, reqwest)
         .version(req.http_version)
-        .headers(req.headers);
+        .headers(req.headers)
+        .query(&req.query_params);
     // todo handle send errors
     // todo handle text errors
     Ok(builder.send().await?.text().await?)

--- a/bin/src/errors.rs
+++ b/bin/src/errors.rs
@@ -28,12 +28,6 @@ pub enum ParsingError {
         filename: String,
         source: std::io::Error,
     },
-    #[error(transparent)]
-    #[diagnostic(
-        code("spec violation: types"),
-        help("usually keys accept only strings or everything except datetimes and tables")
-    )] // todo: url to schema specification
-    WrongType { source: rede_parser::Error },
 }
 
 #[derive(Debug, Diagnostic, Error)]
@@ -81,12 +75,11 @@ impl ParsingError {
 
     pub fn parsing<T: Into<String>>(code: T, source: rede_parser::Error) -> Self {
         match source {
-            rede_parser::Error::InvalidFile(e) => ParsingError::Deserialization {
+            rede_parser::Error::ParsingToml(e) => ParsingError::Deserialization {
                 message: e.message().to_owned(),
                 code: code.into(),
                 span: e.span().map(SourceSpan::from),
             },
-            rede_parser::Error::InvalidType { .. } => ParsingError::WrongType { source },
         }
     }
 }

--- a/bin/tests/inputs/query_params.toml
+++ b/bin/tests/inputs/query_params.toml
@@ -1,0 +1,8 @@
+[http]
+method = "GET"
+url = "http://localhost:8080/api/request"
+
+[query_params]
+size = 10
+page = 1
+name = [ "Robert", "Edward" ]

--- a/bin/tests/run.rs
+++ b/bin/tests/run.rs
@@ -58,7 +58,7 @@ test_request!(query_params -> contains(r#""name":["Robert","Edward"]"#).and(cont
 test_error!(invalid_url -> contains("invalid url"));
 test_error!(failed_connection -> contains("failed connection"));
 test_error!(bad_url_scheme -> contains("failed request building"));
-test_error!(timeout<>, "--timeout", "0s" -> contains("timeout"));
+test_error!(timeout<>, "--timeout", "0ms" -> contains("timeout"));
 
 test_error!(#[ignore] unsupported_http_version -> contains("wrong http version"));
 test_error!(#[ignore] redirect_loop, "--max-redirects", "5" -> contains("redirect"));

--- a/bin/tests/run.rs
+++ b/bin/tests/run.rs
@@ -52,6 +52,7 @@ macro_rules! test_error {
 test_request!(get_simple -> contains(r#"{"hello":"world"}"#));
 test_request!(http_version -> contains(r#""http_version":"HTTP/1.0""#));
 test_request!(headers -> contains(r#""content-type":"application/json""#).and(contains(r#""num_headers":4"#)));
+test_request!(query_params -> contains(r#""name":["Robert","Edward"]"#).and(contains(r#""num_query_params":3"#)));
 // todo -no-redirect, requires --verbose
 
 test_error!(invalid_url -> contains("invalid url"));


### PR DESCRIPTION
Allows `rede run` to send the query params of the request defined in the TOML.
