### PR TITLE
feat: send body on rede run

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -127,9 +127,9 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.22.0"
+version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9475866fec1451be56a3c2400fd081ff546538961565ccb5b7142cbd22bc7a51"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "bitflags"
@@ -382,6 +382,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
 
 [[package]]
+name = "futures-io"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -400,9 +417,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
 dependencies = [
  "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
+ "slab",
 ]
 
 [[package]]
@@ -908,18 +930,17 @@ dependencies = [
  "miette",
  "mime",
  "predicates",
- "rede_parser 0.1.2",
+ "rede_parser 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest",
  "thiserror",
  "tokio",
+ "tokio-util",
  "url",
 ]
 
 [[package]]
 name = "rede_parser"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab99eb3b8479b5aa9b21b9db147254434351a853fcbd9d674b337046ecb4ed0d"
+version = "0.1.3"
 dependencies = [
  "http",
  "http-serde",
@@ -932,6 +953,8 @@ dependencies = [
 [[package]]
 name = "rede_parser"
 version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1d94bf9c3b5c843b2c8b4010739ba5da8a01d66a29adb5beffb4cc33079dfe"
 dependencies = [
  "http",
  "http-serde",
@@ -972,9 +995,9 @@ checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
 
 [[package]]
 name = "reqwest"
-version = "0.12.3"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e6cc1e89e689536eb5aeede61520e874df5a4707df811cd5da4aa5fbb2aae19"
+checksum = "2d66674f2b6fb864665eea7a3c1ac4e3dfacd2fda83cf6f935a612e01b0e3338"
 dependencies = [
  "base64",
  "bytes",
@@ -1004,10 +1027,12 @@ dependencies = [
  "system-configuration",
  "tokio",
  "tokio-native-tls",
+ "tokio-util",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "winreg",
 ]
@@ -1043,19 +1068,12 @@ dependencies = [
 
 [[package]]
 name = "rustls-pemfile"
-version = "2.1.2"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29993a25686778eb88d4189742cd713c9bce943bc54251a33509dc63cbacf73d"
+checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
  "base64",
- "rustls-pki-types",
 ]
-
-[[package]]
-name = "rustls-pki-types"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecd36cc4259e3e4514335c4a138c6b43171a8d61d8f5c9348f9fc7529416f247"
 
 [[package]]
 name = "ryu"
@@ -1591,6 +1609,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
 
 [[package]]
+name = "wasm-streams"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b65dc4c90b63b118468cf747d8bf3566c1913ef60be765b5730ead9e0a3ba129"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1743,9 +1774,9 @@ dependencies = [
 
 [[package]]
 name = "winreg"
-version = "0.52.0"
+version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
+checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
 dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -903,8 +903,10 @@ dependencies = [
  "colored",
  "duration-str",
  "env_logger",
+ "http",
  "log",
  "miette",
+ "mime",
  "predicates",
  "rede_parser 0.1.2",
  "reqwest",
@@ -1327,19 +1329,7 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "socket2",
- "tokio-macros",
  "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "tokio-macros"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -691,6 +691,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "mime_guess"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4192263c238a5f0d0c6bfd21f336a313a4ce1c450542449ca191bb657b4642ef"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1015,6 +1025,7 @@ dependencies = [
  "js-sys",
  "log",
  "mime",
+ "mime_guess",
  "native-tls",
  "once_cell",
  "percent-encoding",
@@ -1463,6 +1474,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "unicase"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d2d4dafb69621809a81864c9c1b864479e1235c0dd4e199924b9742439ed89"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1517,6 +1537,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wait-timeout"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,6 @@ license = "Apache-2.0 OR MIT"
 
 [workspace.dependencies]
 http = "1.1"
-mime = "0.3"
 log = "0.4"
+mime = "0.3"
 thiserror = "1.0"

--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -29,7 +29,7 @@ colored = "2.1.0"
 duration-str = { version = "0.7.1", default-features = false }
 env_logger = "0.11.3"
 miette = { version = "7.2.0", features = ["fancy"] }
-reqwest = { version = "=0.12.2", features = ["stream"] }
+reqwest = { version = "=0.12.2", features = ["multipart", "stream"] }
 tokio = { version = "1.37.0", features = ["fs"] }
 url = "2.5.0"
 tokio-util = { version = "0.7.10", features = ["codec"] }

--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -16,7 +16,7 @@ keywords = [ "cli", "http", "api", "request" ]
 readme = "../README.md"
 
 [dependencies]
-rede_parser = "0.1.2"
+rede_parser = "0.1.3"
 #rede_parser = { path = "../parser" }
 
 http.workspace = true
@@ -29,9 +29,10 @@ colored = "2.1.0"
 duration-str = { version = "0.7.1", default-features = false }
 env_logger = "0.11.3"
 miette = { version = "7.2.0", features = ["fancy"] }
-reqwest = "0.12"
-tokio = "1.37.0"
+reqwest = { version = "=0.12.2", features = ["stream"] }
+tokio = { version = "1.37.0", features = ["fs"] }
 url = "2.5.0"
+tokio-util = { version = "0.7.10", features = ["codec"] }
 
 [dev-dependencies]
 assert_cmd = "2.0.14"

--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -17,8 +17,11 @@ readme = "../README.md"
 
 [dependencies]
 rede_parser = "0.1.2"
+#rede_parser = { path = "../parser" }
 
+http.workspace = true
 log.workspace = true
+mime.workspace = true
 thiserror.workspace = true
 
 clap = { version = "4.5.4", features = ["derive"] }
@@ -27,7 +30,7 @@ duration-str = { version = "0.7.1", default-features = false }
 env_logger = "0.11.3"
 miette = { version = "7.2.0", features = ["fancy"] }
 reqwest = "0.12"
-tokio = { version = "1.37.0", features = ["tokio-macros"] }
+tokio = "1.37.0"
 url = "2.5.0"
 
 [dev-dependencies]

--- a/bin/src/commands/reqwest.rs
+++ b/bin/src/commands/reqwest.rs
@@ -49,7 +49,7 @@ pub async fn send(req: Request, args: RequestArgs) -> Result<String, Error> {
             }
             builder.multipart(form)
         }
-        Body::XFormUrlEncoded(_) => unimplemented!(),
+        Body::XFormUrlEncoded(form) => builder.form(&form),
         Body::None => builder,
     }
     .headers(headers);

--- a/bin/src/commands/run.rs
+++ b/bin/src/commands/run.rs
@@ -3,7 +3,7 @@ use crate::errors::ParsingError;
 use crate::util::input_to_string;
 use clap::Args;
 use colored::Colorize;
-use log::info;
+use log::{debug, info};
 use miette::{miette, LabeledSpan, Report};
 use rede_parser::parse_request;
 use std::time::Duration;
@@ -31,6 +31,8 @@ impl Command {
 
         let content = input_to_string(&self.request)?;
         let request = parse_request(&content).map_err(|e| ParsingError::parsing(content, e))?;
+
+        debug!("{request:?}");
 
         let args = RequestArgs::try_from(&self)?;
         let response = send(request, args).await?;

--- a/bin/tests/inputs/body_binary.toml
+++ b/bin/tests/inputs/body_binary.toml
@@ -1,0 +1,6 @@
+[http]
+method = "POST"
+url = "http://localhost:8080/api/binary"
+
+[body]
+binary = "./tests/util/bin_file_for_test"

--- a/bin/tests/inputs/body_form_data.toml
+++ b/bin/tests/inputs/body_form_data.toml
@@ -1,0 +1,7 @@
+[http]
+method = "POST"
+url = "http://localhost:8080/api/multipart"
+
+[body.form_data]
+raw.text = "agarimo"
+binary.file = "./tests/util/bin_file_for_test"

--- a/bin/tests/inputs/body_form_url_encoded.toml
+++ b/bin/tests/inputs/body_form_url_encoded.toml
@@ -1,0 +1,7 @@
+[http]
+method = "POST"
+url = "http://localhost:8080/api/urlencoded"
+
+[body.form_urlencoded]
+anime = "Evangelion"
+rating = 10

--- a/bin/tests/inputs/wrong_binary.toml
+++ b/bin/tests/inputs/wrong_binary.toml
@@ -1,0 +1,6 @@
+[http]
+method = "POST"
+url = "http://localhost:8080/api/binary"
+
+[body]
+binary = "no_exists.zip"

--- a/bin/tests/run.rs
+++ b/bin/tests/run.rs
@@ -56,6 +56,7 @@ test_request!(query_params -> contains(r#""name":["Robert","Edward"]"#).and(cont
 test_request!(body_raw -> contains("rede,request").and(contains(r#""content-type":"text/plain"#)));
 test_request!(body_binary -> contains(r#""size":8"#).and(contains(r#""content-type":"application/octet-stream""#)));
 test_request!(body_form_data -> contains(r#""text":"agarimo""#).and(contains(r#""binary_size":8"#).and(contains("multipart/form-data; boundary="))));
+test_request!(body_form_url_encoded -> contains(r#""anime":"Evangelion""#).and(contains(r#""content-type":"application/x-www-form-urlencoded""#)));
 test_request!(override_content_type -> contains(r#""content-type":"application/json""#));
 // todo -no-redirect, requires --verbose
 

--- a/bin/tests/run.rs
+++ b/bin/tests/run.rs
@@ -51,15 +51,18 @@ macro_rules! test_error {
 
 test_request!(get_simple -> contains(r#"{"hello":"world"}"#));
 test_request!(http_version -> contains(r#""http_version":"HTTP/1.0""#));
-test_request!(headers -> contains(r#""content-type":"application/json""#).and(contains(r#""num_headers":4"#)));
+test_request!(headers -> contains(r#""content-type":"application/json""#).and(contains(r#""num_headers":5"#)));
 test_request!(query_params -> contains(r#""name":["Robert","Edward"]"#).and(contains(r#""num_query_params":3"#)));
 test_request!(body_raw -> contains("rede,request").and(contains(r#""content-type":"text/plain"#)));
+test_request!(body_binary -> contains(r#""size":8"#).and(contains(r#""content-type":"application/octet-stream""#)));
 test_request!(override_content_type -> contains(r#""content-type":"application/json""#));
 // todo -no-redirect, requires --verbose
 
-test_error!(invalid_url -> contains("invalid url"));
-test_error!(failed_connection -> contains("failed connection"));
-test_error!(bad_url_scheme -> contains("failed request building"));
+test_error!(missing_file -> contains("invalid [REQUEST]").and(contains("No such file or directory")));
+test_error!(invalid_url -> contains("invalid url").and(contains("http://128.0.0.256")));
+test_error!(failed_connection -> contains("failed connection").and(contains("completelymadeupurl")));
+test_error!(bad_url_scheme -> contains("failed request building").and(contains("htt:/www.url.com")));
+test_error!(wrong_binary -> contains("invalid file").and(contains("no_exists.zip")));
 test_error!(timeout<>, "--timeout", "0ms" -> contains("timeout"));
 
 test_error!(#[ignore] unsupported_http_version -> contains("wrong http version"));

--- a/bin/tests/run.rs
+++ b/bin/tests/run.rs
@@ -55,6 +55,7 @@ test_request!(headers -> contains(r#""content-type":"application/json""#).and(co
 test_request!(query_params -> contains(r#""name":["Robert","Edward"]"#).and(contains(r#""num_query_params":3"#)));
 test_request!(body_raw -> contains("rede,request").and(contains(r#""content-type":"text/plain"#)));
 test_request!(body_binary -> contains(r#""size":8"#).and(contains(r#""content-type":"application/octet-stream""#)));
+test_request!(body_form_data -> contains(r#""text":"agarimo""#).and(contains(r#""binary_size":8"#).and(contains("multipart/form-data; boundary="))));
 test_request!(override_content_type -> contains(r#""content-type":"application/json""#));
 // todo -no-redirect, requires --verbose
 

--- a/bin/tests/run.rs
+++ b/bin/tests/run.rs
@@ -53,6 +53,8 @@ test_request!(get_simple -> contains(r#"{"hello":"world"}"#));
 test_request!(http_version -> contains(r#""http_version":"HTTP/1.0""#));
 test_request!(headers -> contains(r#""content-type":"application/json""#).and(contains(r#""num_headers":4"#)));
 test_request!(query_params -> contains(r#""name":["Robert","Edward"]"#).and(contains(r#""num_query_params":3"#)));
+test_request!(body_raw -> contains("rede,request").and(contains(r#""content-type":"text/plain"#)));
+test_request!(override_content_type -> contains(r#""content-type":"application/json""#));
 // todo -no-redirect, requires --verbose
 
 test_error!(invalid_url -> contains("invalid url"));

--- a/bin/tests/util/bin_file_for_test
+++ b/bin/tests/util/bin_file_for_test
@@ -1,0 +1,1 @@
+afouteza


### PR DESCRIPTION
Allows `rede run` to send the body specified in the `[REQUEST]`. Support all five types.

- **feat: support raw body**
- **feat: support binary body**
- **feat: support multipart body**
- **feat: support form urlencoded**
