### PR TITLE
tyding: create client entity

### DIFF
--- a/bin/src/commands/reqwest.rs
+++ b/bin/src/commands/reqwest.rs
@@ -1,4 +1,4 @@
-use crate::commands::run::RequestArgs;
+use crate::commands::run::ClientProperties;
 use http::header::CONTENT_TYPE;
 use http::HeaderMap;
 use log::debug;
@@ -6,7 +6,7 @@ use mime::Mime;
 use rede_parser::body::FormDataValue;
 use rede_parser::{Body, Request};
 use reqwest::redirect::Policy;
-use reqwest::{multipart, Client, ClientBuilder, Request as Reqwest, RequestBuilder, Url};
+use reqwest::{multipart, ClientBuilder, Request as Reqwest, RequestBuilder, Url};
 use tokio::fs::File;
 use tokio_util::codec::{BytesCodec, FramedRead};
 
@@ -14,60 +14,70 @@ use crate::errors::RequestError;
 
 type Error = RequestError<reqwest::Error>;
 
-pub async fn send(req: Request, args: RequestArgs) -> Result<String, Error> {
-    let url = Url::parse(&req.url).map_err(|e| RequestError::invalid_url(&req.url, e))?;
-
-    let client = build_client(&args)?;
-    let reqwest = Reqwest::new(req.method, url);
-
-    let builder = RequestBuilder::from_parts(client, reqwest)
-        .version(req.http_version)
-        .query(&req.query_params);
-
-    let mut headers = req.headers;
-
-    let builder = match req.body {
-        Body::Raw { mime, content } => {
-            set_content_type(&mut headers, &mime);
-            builder.body(content)
-        }
-        Body::Binary { mime, path } => {
-            set_content_type(&mut headers, &mime);
-            let body = file_to_body(&path).await?;
-            builder.body(body)
-        }
-        Body::FormData(map) => {
-            let mut form = multipart::Form::new();
-            for (k, v) in map {
-                form = match v {
-                    FormDataValue::Text(content) => form.text(k, content),
-                    FormDataValue::File(path) => {
-                        let body = file_to_body(&path).await?;
-                        form.part(k, multipart::Part::stream(body))
-                    }
-                }
-            }
-            builder.multipart(form)
-        }
-        Body::XFormUrlEncoded(form) => builder.form(&form),
-        Body::None => builder,
-    }
-    .headers(headers);
-
-    Ok(builder.send().await?.text().await?)
+pub struct Client {
+    properties: ClientProperties,
 }
 
-fn build_client(args: &RequestArgs) -> Result<Client, reqwest::Error> {
-    let mut client = ClientBuilder::new();
-    if let Some(timeout) = args.timeout {
-        client = client.timeout(timeout);
+impl Client {
+    pub fn new(properties: ClientProperties) -> Self {
+        Self { properties }
     }
-    client = match (args.no_redirect, args.max_redirects) {
-        (true, _) => client.redirect(Policy::none()),
-        (false, Some(val)) => client.redirect(Policy::limited(val)),
-        _ => client,
-    };
-    client.build()
+
+    pub async fn send(self, req: Request) -> Result<String, Error> {
+        let url = Url::parse(&req.url).map_err(|e| RequestError::invalid_url(&req.url, e))?;
+
+        let client = self.build_client()?;
+        let reqwest = Reqwest::new(req.method, url);
+
+        let builder = RequestBuilder::from_parts(client, reqwest)
+            .version(req.http_version)
+            .query(&req.query_params);
+
+        let mut headers = req.headers;
+
+        let builder = match req.body {
+            Body::Raw { mime, content } => {
+                set_content_type(&mut headers, &mime);
+                builder.body(content)
+            }
+            Body::Binary { mime, path } => {
+                set_content_type(&mut headers, &mime);
+                let body = file_to_body(&path).await?;
+                builder.body(body)
+            }
+            Body::FormData(map) => {
+                let mut form = multipart::Form::new();
+                for (k, v) in map {
+                    form = match v {
+                        FormDataValue::Text(content) => form.text(k, content),
+                        FormDataValue::File(path) => {
+                            let body = file_to_body(&path).await?;
+                            form.part(k, multipart::Part::stream(body))
+                        }
+                    }
+                }
+                builder.multipart(form)
+            }
+            Body::XFormUrlEncoded(form) => builder.form(&form),
+            Body::None => builder,
+        }
+        .headers(headers);
+
+        Ok(builder.send().await?.text().await?)
+    }
+
+    fn build_client(&self) -> Result<reqwest::Client, reqwest::Error> {
+        let mut client = ClientBuilder::new();
+        if let Some(timeout) = self.properties.timeout {
+            client = client.timeout(timeout);
+        }
+        client = match (self.properties.no_redirect, self.properties.max_redirects) {
+            (true, _) => client.redirect(Policy::none()),
+            (false, Some(val)) => client.redirect(Policy::limited(val)),
+            _ => client,
+        };
+        client.build()
+    }
 }
 
 fn set_content_type(headers: &mut HeaderMap, mime: &Mime) {

--- a/bin/src/commands/run.rs
+++ b/bin/src/commands/run.rs
@@ -1,4 +1,4 @@
-use crate::commands::reqwest::send;
+use crate::commands::reqwest::Client;
 use crate::errors::ParsingError;
 use crate::util::input_to_string;
 use clap::Args;
@@ -34,21 +34,21 @@ impl Command {
 
         debug!("{request:?}");
 
-        let args = RequestArgs::try_from(&self)?;
-        let response = send(request, args).await?;
+        let client = Client::new((&self).try_into()?);
+        let response = client.send(request).await?;
 
-        println!("{}", response.bold());
+        println!("{}", response.italic());
         Ok(())
     }
 }
 
-pub struct RequestArgs {
+pub struct ClientProperties {
     pub timeout: Option<Duration>,
     pub no_redirect: bool,
     pub max_redirects: Option<usize>,
 }
 
-impl TryFrom<&Command> for RequestArgs {
+impl TryFrom<&Command> for ClientProperties {
     type Error = Report;
 
     fn try_from(value: &Command) -> Result<Self, Self::Error> {
@@ -69,7 +69,7 @@ impl TryFrom<&Command> for RequestArgs {
                 .with_source_code(t.to_owned())
             })?;
 
-        Ok(RequestArgs {
+        Ok(ClientProperties {
             timeout,
             no_redirect: value.no_redirect,
             max_redirects: value.max_redirects,


### PR DESCRIPTION
Encapsulates the request logic into a client built from the properties that sends the request.
