### PR TITLE
feat: printing modes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -235,6 +235,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.15.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e1f83fc076bd6dd27517eacdf25fef6c4dfe5f1d7448bafaaf3a26f13b5e4eb"
+dependencies = [
+ "encode_unicode",
+ "lazy_static",
+ "libc",
+ "unicode-width",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -272,6 +285,12 @@ dependencies = [
  "rust_decimal",
  "thiserror",
 ]
+
+[[package]]
+name = "encode_unicode"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "encoding_rs"
@@ -933,6 +952,7 @@ dependencies = [
  "assert_cmd",
  "clap",
  "colored",
+ "console",
  "duration-str",
  "env_logger",
  "http",

--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -33,6 +33,7 @@ reqwest = { version = "=0.12.2", features = ["multipart", "stream"] }
 tokio = { version = "1.37.0", features = ["fs"] }
 url = "2.5.0"
 tokio-util = { version = "0.7.10", features = ["codec"] }
+console = "0.15.8"
 
 [dev-dependencies]
 assert_cmd = "2.0.14"

--- a/bin/src/commands.rs
+++ b/bin/src/commands.rs
@@ -8,6 +8,12 @@ mod run;
 pub(crate) struct Cli {
     #[command(subcommand)]
     command: Command,
+    /// Enables all printing messages
+    #[arg(long, conflicts_with = "quiet")]
+    verbose: bool,
+    /// Disables all printing messages
+    #[arg(long)]
+    quiet: bool,
 }
 
 impl Cli {

--- a/bin/src/commands.rs
+++ b/bin/src/commands.rs
@@ -36,11 +36,14 @@ enum Command {
     Run(run::Command),
 }
 
-impl Command {
-    pub async fn run(self) -> miette::Result<()> {
+trait RedeCommand {
+    async fn run(self) -> miette::Result<()>;
+}
+
+impl RedeCommand for Command {
+    async fn run(self) -> miette::Result<()> {
         match self {
-            Command::Run(c) => c.run(),
+            Command::Run(c) => c.run().await,
         }
-        .await
     }
 }

--- a/bin/src/commands.rs
+++ b/bin/src/commands.rs
@@ -1,3 +1,4 @@
+use crate::terminal::{Terminal, TERM_LOCK};
 use clap::{Parser, Subcommand};
 
 mod reqwest;
@@ -18,6 +19,10 @@ pub(crate) struct Cli {
 
 impl Cli {
     pub fn run(self) -> miette::Result<()> {
+        TERM_LOCK
+            .set(Terminal::new(self.quiet, self.verbose))
+            .expect("terminal to be created");
+
         tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build()

--- a/bin/src/commands.rs
+++ b/bin/src/commands.rs
@@ -15,12 +15,15 @@ pub(crate) struct Cli {
     /// Disables all printing messages
     #[arg(long)]
     quiet: bool,
+    /// Disables output coloring
+    #[arg(long)]
+    no_color: bool,
 }
 
 impl Cli {
     pub fn run(self) -> miette::Result<()> {
         TERM_LOCK
-            .set(Terminal::new(self.quiet, self.verbose))
+            .set(Terminal::new(self.quiet, self.verbose, self.no_color))
             .expect("terminal to be created");
 
         tokio::runtime::Builder::new_current_thread()

--- a/bin/src/commands/run.rs
+++ b/bin/src/commands/run.rs
@@ -1,4 +1,5 @@
 use crate::commands::reqwest::Client;
+use crate::commands::RedeCommand;
 use crate::errors::ParsingError;
 use crate::util::input_to_string;
 use crate::{standard, verbose};
@@ -26,8 +27,8 @@ pub struct Command {
     max_redirects: Option<usize>,
 }
 
-impl Command {
-    pub async fn run(self) -> miette::Result<()> {
+impl RedeCommand for Command {
+    async fn run(self) -> miette::Result<()> {
         info!("Launched rede run with {}", self.request);
 
         let content = input_to_string(&self.request)?;
@@ -42,7 +43,9 @@ impl Command {
         standard!("{}", response.italic());
         Ok(())
     }
+}
 
+impl Command {
     fn print_request(&self, request: &Request) {
         debug!("{request:?}");
 

--- a/bin/src/main.rs
+++ b/bin/src/main.rs
@@ -6,6 +6,7 @@ use crate::commands::Cli;
 
 mod commands;
 mod errors;
+mod terminal;
 mod util;
 
 fn main() -> miette::Result<()> {

--- a/bin/src/terminal.rs
+++ b/bin/src/terminal.rs
@@ -5,6 +5,7 @@ pub static TERM_LOCK: OnceLock<Terminal> = OnceLock::new();
 #[macro_export]
 macro_rules! standard {
     ($($arg:tt)*) => {{
+        use $crate::terminal::TERM_LOCK;
         TERM_LOCK.get().unwrap().print_standard(format!($($arg)*));
     }}
 }
@@ -12,6 +13,7 @@ macro_rules! standard {
 #[macro_export]
 macro_rules! verbose {
     ($($arg:tt)*) => {{
+        use $crate::terminal::TERM_LOCK;
         TERM_LOCK.get().unwrap().print_verbose(format!($($arg)*));
     }}
 }
@@ -32,7 +34,6 @@ impl Terminal {
         Self { mode }
     }
 
-    #[allow(dead_code)]
     #[inline]
     pub fn print_standard(&self, msg: impl AsRef<str>) {
         match self.mode {
@@ -41,7 +42,6 @@ impl Terminal {
         }
     }
 
-    #[allow(dead_code)]
     #[inline]
     pub fn print_verbose(&self, msg: impl AsRef<str>) {
         if self.mode == Mode::Verbose {

--- a/bin/src/terminal.rs
+++ b/bin/src/terminal.rs
@@ -1,0 +1,58 @@
+use std::sync::OnceLock;
+
+pub static TERM_LOCK: OnceLock<Terminal> = OnceLock::new();
+
+#[macro_export]
+macro_rules! standard {
+    ($($arg:tt)*) => {{
+        TERM_LOCK.get().unwrap().print_standard(format!($($arg)*));
+    }}
+}
+
+#[macro_export]
+macro_rules! verbose {
+    ($($arg:tt)*) => {{
+        TERM_LOCK.get().unwrap().print_verbose(format!($($arg)*));
+    }}
+}
+
+#[derive(Debug)]
+pub struct Terminal {
+    mode: Mode,
+}
+
+impl Terminal {
+    pub fn new(quiet: bool, verbose: bool) -> Self {
+        let mode = match (quiet, verbose) {
+            (true, false) => Mode::Quiet,
+            (false, true) => Mode::Verbose,
+            (false, false) => Mode::Standard,
+            (true, true) => unreachable!("quiet and verbose are mutually exclusive"),
+        };
+        Self { mode }
+    }
+
+    #[allow(dead_code)]
+    #[inline]
+    pub fn print_standard(&self, msg: impl AsRef<str>) {
+        match self.mode {
+            Mode::Standard | Mode::Verbose => println!("{}", msg.as_ref()),
+            Mode::Quiet => {}
+        }
+    }
+
+    #[allow(dead_code)]
+    #[inline]
+    pub fn print_verbose(&self, msg: impl AsRef<str>) {
+        if self.mode == Mode::Verbose {
+            println!("{}", msg.as_ref());
+        }
+    }
+}
+
+#[derive(Debug, PartialEq)]
+enum Mode {
+    Quiet,
+    Standard,
+    Verbose,
+}

--- a/bin/src/terminal.rs
+++ b/bin/src/terminal.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::sync::OnceLock;
 
 pub static TERM_LOCK: OnceLock<Terminal> = OnceLock::new();
@@ -21,23 +22,25 @@ macro_rules! verbose {
 #[derive(Debug)]
 pub struct Terminal {
     mode: Mode,
+    no_color: bool,
 }
 
 impl Terminal {
-    pub fn new(quiet: bool, verbose: bool) -> Self {
+    pub fn new(quiet: bool, verbose: bool, no_color: bool) -> Self {
         let mode = match (quiet, verbose) {
             (true, false) => Mode::Quiet,
             (false, true) => Mode::Verbose,
             (false, false) => Mode::Standard,
             (true, true) => unreachable!("quiet and verbose are mutually exclusive"),
         };
-        Self { mode }
+        Self { mode, no_color }
     }
 
     #[inline]
     pub fn print_standard(&self, msg: impl AsRef<str>) {
+        let msg = self.remove_color(msg.as_ref());
         match self.mode {
-            Mode::Standard | Mode::Verbose => println!("{}", msg.as_ref()),
+            Mode::Standard | Mode::Verbose => println!("{msg}"),
             Mode::Quiet => {}
         }
     }
@@ -45,7 +48,16 @@ impl Terminal {
     #[inline]
     pub fn print_verbose(&self, msg: impl AsRef<str>) {
         if self.mode == Mode::Verbose {
-            println!("{}", msg.as_ref());
+            println!("{}", self.remove_color(msg.as_ref()));
+        }
+    }
+
+    #[inline]
+    fn remove_color<'a>(&self, msg: &'a str) -> Cow<'a, str> {
+        if self.no_color {
+            console::strip_ansi_codes(msg)
+        } else {
+            msg.into()
         }
     }
 }

--- a/bin/tests/root.rs
+++ b/bin/tests/root.rs
@@ -1,0 +1,35 @@
+use assert_cmd::Command;
+use predicates::str::contains;
+
+#[test]
+fn help_by_default() {
+    Command::cargo_bin("rede")
+        .unwrap()
+        .assert()
+        .failure()
+        .stderr(contains("--help"));
+}
+
+#[test]
+fn subcommand_required() {
+    Command::cargo_bin("rede")
+        .unwrap()
+        .arg("--quiet")
+        .assert()
+        .failure()
+        .stderr(contains("requires a subcommand"));
+}
+
+#[test]
+fn quiet_and_verbose_exclusive() {
+    Command::cargo_bin("rede")
+        .unwrap()
+        .arg("--quiet")
+        .arg("--verbose")
+        .arg("run")
+        .assert()
+        .failure()
+        .stderr(contains(
+            "the argument '--quiet' cannot be used with '--verbose'",
+        ));
+}

--- a/bin/tests/root.rs
+++ b/bin/tests/root.rs
@@ -1,35 +1,22 @@
 use assert_cmd::Command;
 use predicates::str::contains;
 
-#[test]
-fn help_by_default() {
-    Command::cargo_bin("rede")
-        .unwrap()
-        .assert()
-        .failure()
-        .stderr(contains("--help"));
+macro_rules! test_failure {
+    ($(#[$m:meta])*$name:ident: $($arg:literal),* -> $assert:expr) => {
+        $(#[$m])*
+        #[test]
+        fn $name() {
+            Command::cargo_bin("rede")
+                .unwrap()
+                $(.arg($arg))*
+                .assert()
+                .failure()
+                .stderr($assert);
+        }
+    };
 }
 
-#[test]
-fn subcommand_required() {
-    Command::cargo_bin("rede")
-        .unwrap()
-        .arg("--quiet")
-        .assert()
-        .failure()
-        .stderr(contains("requires a subcommand"));
-}
-
-#[test]
-fn quiet_and_verbose_exclusive() {
-    Command::cargo_bin("rede")
-        .unwrap()
-        .arg("--quiet")
-        .arg("--verbose")
-        .arg("run")
-        .assert()
-        .failure()
-        .stderr(contains(
-            "the argument '--quiet' cannot be used with '--verbose'",
-        ));
-}
+test_failure!(help_by_default: -> contains("--help"));
+test_failure!(subcommand_required: "--quiet" -> contains("requires a subcommand"));
+test_failure!(quiet_and_verbose_mutually_exclusive: "--quiet", "--verbose", "run" ->
+   contains("the argument '--quiet' cannot be used with '--verbose'"));

--- a/bin/tests/run.rs
+++ b/bin/tests/run.rs
@@ -5,34 +5,8 @@ use predicates::prelude::predicate::str::contains;
 // Set of integration tests for `rede run`, they are all ignored to run them only manually.
 // The majority of these tests are built against a custom test API
 
-macro_rules! test_request {
-    ($name:ident -> $assert:expr) => {
-        #[test]
-        #[ignore]
-        fn $name() {
-            let file = format!("tests/inputs/{}", stringify!($name));
-            Command::cargo_bin("rede")
-                .unwrap()
-                .arg("run")
-                .arg(file)
-                .assert()
-                .success()
-                .stdout($assert);
-        }
-    };
-}
-
-macro_rules! test_error {
-    // Runs the test using the file matching the test name
-    ($(#[$m:meta])*$name:ident $(, $arg:literal)* -> $assert:expr) => {
-        test_error!($(#[$m])*$name <$name>, $($arg),* -> $assert);
-    };
-    // Runs the test using the `get_simple` file, for test not dependent on the request file
-    ($(#[$m:meta])*$name:ident <>, $($arg:literal),* -> $assert:expr) => {
-        test_error!($(#[$m])*$name <get_simple>, $($arg),* -> $assert);
-    };
-    // Runs the test using the given file
-    ($(#[$m:meta])*$name:ident <$file:ident>, $($arg:literal),* -> $assert:expr) => {
+macro_rules! test_req {
+    ($(#[$m:meta])*$name:ident, $result:ident, $std:ident, <$file:ident> $($arg:literal),* -> $assert:expr) => {
         $(#[$m])*
         #[test]
         fn $name() {
@@ -43,9 +17,33 @@ macro_rules! test_error {
                 $(.arg($arg))*
                 .arg(file)
                 .assert()
-                .failure()
-                .stderr($assert);
+                .$result()
+                .$std($assert);
         }
+    };
+}
+
+macro_rules! test_request {
+    ($name:ident -> $assert:expr) => {
+        test_req!(#[ignore]$name, success, stdout, <$name> -> $assert);
+    };
+    ($name:ident <$file:ident> -> $assert:expr) => {
+        test_req!(#[ignore]$name, success, stdout, <$file> -> $assert);
+    };
+}
+
+macro_rules! test_error {
+    // Runs the test using the file matching the test name
+    ($(#[$m:meta])*$name:ident $(, $arg:literal)* -> $assert:expr) => {
+        test_req!($(#[$m])*$name, failure, stderr, <$name> $($arg),* -> $assert);
+    };
+    // Runs the test using the `get_simple` file, for test not dependent on the request file
+    ($(#[$m:meta])*$name:ident <> $($arg:literal),* -> $assert:expr) => {
+        test_req!($(#[$m])*$name, failure, stderr, <get_simple> $($arg),* -> $assert);
+    };
+    // Runs the test using the given file
+    ($(#[$m:meta])*$name:ident <$file:ident> $($arg:literal),* -> $assert:expr) => {
+        test_req!($(#[$m])*$name, failure, stderr, <$file> $($arg),* -> $assert);
     };
 }
 
@@ -65,7 +63,7 @@ test_error!(invalid_url -> contains("invalid url").and(contains("http://128.0.0.
 test_error!(failed_connection -> contains("failed connection").and(contains("completelymadeupurl")));
 test_error!(bad_url_scheme -> contains("failed request building").and(contains("htt:/www.url.com")));
 test_error!(wrong_binary -> contains("invalid file").and(contains("no_exists.zip")));
-test_error!(timeout<>, "--timeout", "0ms" -> contains("timeout"));
 
+test_error!(#[ignore] timeout<> "--timeout", "0ms" -> contains("timeout"));
 test_error!(#[ignore] unsupported_http_version -> contains("wrong http version"));
 test_error!(#[ignore] redirect_loop, "--max-redirects", "5" -> contains("redirect"));


### PR DESCRIPTION
Adds new output messages when using `rede run`.
Allow control of terminal output with three new flags:
- `--no-color`
- `--quiet`
- `--verbose`

- **feat: define verbose and quiet flags**
- **feat: create terminal wrapper**
- **feat: add output on run**
- **tyding: extract command trait**
- **tyding: add macros to root tests**
- **test: improve run tests**
- **feat: --no-color**
