### PR TITLE
fix: --no-color working on errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -225,16 +225,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
-name = "colored"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbf2150cce219b664a8a70df7a1f933836724b503f8a413af9365b4dcc4d90b8"
-dependencies = [
- "lazy_static",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "console"
 version = "0.15.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -951,7 +941,6 @@ version = "0.1.0"
 dependencies = [
  "assert_cmd",
  "clap",
- "colored",
  "console",
  "duration-str",
  "env_logger",

--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -25,7 +25,6 @@ mime.workspace = true
 thiserror.workspace = true
 
 clap = { version = "4.5.4", features = ["derive"] }
-colored = "2.1.0"
 duration-str = { version = "0.7.1", default-features = false }
 env_logger = "0.11.3"
 miette = { version = "7.2.0", features = ["fancy"] }

--- a/bin/src/commands/run.rs
+++ b/bin/src/commands/run.rs
@@ -4,7 +4,7 @@ use crate::errors::ParsingError;
 use crate::util::input_to_string;
 use crate::{standard, verbose};
 use clap::Args;
-use colored::Colorize;
+use console::style;
 use log::{debug, info, trace};
 use miette::{miette, LabeledSpan, Report};
 use rede_parser::{parse_request, Request};
@@ -40,7 +40,7 @@ impl RedeCommand for Command {
         let client = Client::new((&self).try_into()?);
         let response = client.send(request).await?;
 
-        standard!("{}", response.italic());
+        standard!("{}", style(response).italic());
         Ok(())
     }
 }
@@ -51,12 +51,8 @@ impl Command {
 
         standard!(
             "{} Executing request {}\n",
-            ">".bold().cyan(),
-            request
-                .metadata
-                .get("name")
-                .unwrap_or(&self.request)
-                .yellow()
+            style(">").bold().cyan(),
+            style(request.metadata.get("name").unwrap_or(&self.request)).yellow()
         );
 
         let query = if request.query_params.is_empty() {
@@ -76,8 +72,8 @@ impl Command {
         // TODO print each method in a different color
         verbose!(
             "{} {}",
-            request.method.as_str().yellow(),
-            url.underline().cyan()
+            style(request.method.as_str()).yellow(),
+            style(url).underlined().cyan()
         );
 
         // TODO use if_verbose! to omit this loop
@@ -115,7 +111,7 @@ impl TryFrom<&Command> for ClientProperties {
                     help = "duration is usually represented like: [0-9]+(ns|us|ms|[smhdwy])",
                     labels = vec![LabeledSpan::at(0..t.len(), "wrong value")],
                     "Failed to convert the {} into a valid duration",
-                    "--timeout".italic().yellow()
+                    style("--timeout").italic().yellow()
                 )
                 .with_source_code(t.to_owned())
             })?;

--- a/bin/src/errors.rs
+++ b/bin/src/errors.rs
@@ -1,4 +1,4 @@
-use colored::Colorize;
+use console::style;
 use miette::{Diagnostic, SourceSpan};
 use std::error::{Error as StdError, Error};
 use std::io::Error as IOError;
@@ -20,7 +20,7 @@ pub enum ParsingError {
         #[label("here")]
         span: Option<SourceSpan>,
     },
-    #[error("Failed to read {}", filename.yellow())]
+    #[error("Failed to read {}", style(filename).yellow())]
     #[diagnostic(
         code("invalid [REQUEST]"),
         help("check if the file name is correct or you're in the correct path")
@@ -36,13 +36,13 @@ pub enum RequestError<E: Error> {
     #[error(transparent)]
     #[diagnostic(code = "failed connection")]
     FailedConnection(E),
-    #[error("resulting url is not correct ({})", url.underline().blue())]
+    #[error("resulting url is not correct ({})", style(url).underlined().blue())]
     #[diagnostic(code("invalid url"))]
     InvalidUrl {
         url: String,
         source: url::ParseError,
     },
-    #[error("a file defined on the request could not be loaded: {}", filename.yellow())]
+    #[error("a file defined on the request could not be loaded: {}", style(filename).yellow())]
     #[diagnostic(
         code("invalid file"),
         help(

--- a/bin/src/terminal.rs
+++ b/bin/src/terminal.rs
@@ -1,4 +1,3 @@
-use std::borrow::Cow;
 use std::sync::OnceLock;
 
 pub static TERM_LOCK: OnceLock<Terminal> = OnceLock::new();
@@ -22,25 +21,23 @@ macro_rules! verbose {
 #[derive(Debug)]
 pub struct Terminal {
     mode: Mode,
-    no_color: bool,
 }
 
 impl Terminal {
-    pub fn new(quiet: bool, verbose: bool, no_color: bool) -> Self {
+    pub fn new(quiet: bool, verbose: bool) -> Self {
         let mode = match (quiet, verbose) {
             (true, false) => Mode::Quiet,
             (false, true) => Mode::Verbose,
             (false, false) => Mode::Standard,
             (true, true) => unreachable!("quiet and verbose are mutually exclusive"),
         };
-        Self { mode, no_color }
+        Self { mode }
     }
 
     #[inline]
     pub fn print_standard(&self, msg: impl AsRef<str>) {
-        let msg = self.remove_color(msg.as_ref());
         match self.mode {
-            Mode::Standard | Mode::Verbose => println!("{msg}"),
+            Mode::Standard | Mode::Verbose => println!("{}", msg.as_ref()),
             Mode::Quiet => {}
         }
     }
@@ -48,16 +45,7 @@ impl Terminal {
     #[inline]
     pub fn print_verbose(&self, msg: impl AsRef<str>) {
         if self.mode == Mode::Verbose {
-            println!("{}", self.remove_color(msg.as_ref()));
-        }
-    }
-
-    #[inline]
-    fn remove_color<'a>(&self, msg: &'a str) -> Cow<'a, str> {
-        if self.no_color {
-            console::strip_ansi_codes(msg)
-        } else {
-            msg.into()
+            println!("{}", msg.as_ref());
         }
     }
 }


### PR DESCRIPTION
Changes to use `console` crate for coloring and defines a custom miette report handler, allowing tu turn off colors on errors too.
