### PR TITLE
feat: print response

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -951,6 +951,7 @@ dependencies = [
  "predicates",
  "rede_parser 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest",
+ "serde_json",
  "thiserror",
  "tokio",
  "tokio-util",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -949,7 +949,7 @@ dependencies = [
  "miette",
  "mime",
  "predicates",
- "rede_parser 0.1.3",
+ "rede_parser 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest",
  "thiserror",
  "tokio",
@@ -959,9 +959,7 @@ dependencies = [
 
 [[package]]
 name = "rede_parser"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1d94bf9c3b5c843b2c8b4010739ba5da8a01d66a29adb5beffb4cc33079dfe"
+version = "0.1.4"
 dependencies = [
  "http",
  "http-serde",
@@ -974,6 +972,8 @@ dependencies = [
 [[package]]
 name = "rede_parser"
 version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "208525f68b8de2cca220b3cee4346e6e4741bcaf83c6e70825842a05a0b8cca3"
 dependencies = [
  "http",
  "http-serde",

--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -16,7 +16,7 @@ keywords = [ "cli", "http", "api", "request" ]
 readme = "../README.md"
 
 [dependencies]
-rede_parser = "0.1.3"
+rede_parser = "0.1.4"
 #rede_parser = { path = "../parser" }
 
 http.workspace = true

--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -28,7 +28,7 @@ clap = { version = "4.5.4", features = ["derive"] }
 duration-str = { version = "0.7.1", default-features = false }
 env_logger = "0.11.3"
 miette = { version = "7.2.0", features = ["fancy"] }
-reqwest = { version = "=0.12.2", features = ["json", "multipart", "stream"] }
+reqwest = { version = "=0.12.2", features = ["multipart", "stream"] }
 tokio = { version = "1.37.0", features = ["fs"] }
 url = "2.5.0"
 tokio-util = { version = "0.7.10", features = ["codec"] }

--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -28,11 +28,12 @@ clap = { version = "4.5.4", features = ["derive"] }
 duration-str = { version = "0.7.1", default-features = false }
 env_logger = "0.11.3"
 miette = { version = "7.2.0", features = ["fancy"] }
-reqwest = { version = "=0.12.2", features = ["multipart", "stream"] }
+reqwest = { version = "=0.12.2", features = ["json", "multipart", "stream"] }
 tokio = { version = "1.37.0", features = ["fs"] }
 url = "2.5.0"
 tokio-util = { version = "0.7.10", features = ["codec"] }
 console = "0.15.8"
+serde_json = "1.0.115"
 
 [dev-dependencies]
 assert_cmd = "2.0.14"

--- a/bin/src/commands/reqwest.rs
+++ b/bin/src/commands/reqwest.rs
@@ -6,7 +6,7 @@ use mime::Mime;
 use rede_parser::body::FormDataValue;
 use rede_parser::{Body, Request};
 use reqwest::redirect::Policy;
-use reqwest::{multipart, ClientBuilder, Request as Reqwest, RequestBuilder, Url};
+use reqwest::{multipart, ClientBuilder, Request as Reqwest, RequestBuilder, Response, Url};
 use tokio::fs::File;
 use tokio_util::codec::{BytesCodec, FramedRead};
 
@@ -23,7 +23,7 @@ impl Client {
         Self { properties }
     }
 
-    pub async fn send(self, req: Request) -> Result<String, Error> {
+    pub async fn send(self, req: Request) -> Result<Response, Error> {
         let url = Url::parse(&req.url).map_err(|e| RequestError::invalid_url(&req.url, e))?;
 
         let client = self.build_client()?;
@@ -63,7 +63,7 @@ impl Client {
         }
         .headers(headers);
 
-        Ok(builder.send().await?.text().await?)
+        Ok(builder.send().await?)
     }
 
     fn build_client(&self) -> Result<reqwest::Client, reqwest::Error> {

--- a/bin/src/commands/run.rs
+++ b/bin/src/commands/run.rs
@@ -3,7 +3,6 @@ mod print;
 use crate::commands::reqwest::Client;
 use crate::commands::RedeCommand;
 use crate::errors::ParsingError;
-use crate::standard;
 use crate::util::input_to_string;
 use clap::Args;
 use console::style;
@@ -41,8 +40,8 @@ impl RedeCommand for Command {
 
         let client = Client::new((&self).try_into()?);
         let response = client.send(request).await?;
+        print::print_response(&response);
 
-        standard!("{}", style(response).italic());
         Ok(())
     }
 }

--- a/bin/src/commands/run.rs
+++ b/bin/src/commands/run.rs
@@ -4,7 +4,7 @@ use crate::commands::reqwest::Client;
 use crate::commands::RedeCommand;
 use crate::errors::ParsingError;
 use crate::util::input_to_string;
-use clap::Args;
+use clap::{ArgAction, Args};
 use console::style;
 use log::{info, trace};
 use miette::{miette, LabeledSpan, Report};
@@ -17,6 +17,16 @@ pub struct Command {
     /// Request file to execute
     #[arg(default_value = "-")]
     request: String,
+    /// Specifies if formatting applied should be applied to response body, by default is true
+    #[arg(
+        long,
+        default_missing_value("true"),
+        default_value("true"),
+        num_args(0..=1),
+        require_equals(true),
+        action = ArgAction::Set,
+    )]
+    pretty_print: bool,
     /// Timeout, in a string like [0-9]+(ns|us|ms|[smhdwy], for example "3m"
     #[arg(long)]
     timeout: Option<String>,
@@ -40,7 +50,7 @@ impl RedeCommand for Command {
 
         let client = Client::new((&self).try_into()?);
         let response = client.send(request).await?;
-        print::print_response(response).await;
+        self.print_response(response).await;
 
         Ok(())
     }

--- a/bin/src/commands/run.rs
+++ b/bin/src/commands/run.rs
@@ -40,7 +40,7 @@ impl RedeCommand for Command {
 
         let client = Client::new((&self).try_into()?);
         let response = client.send(request).await?;
-        print::print_response(&response);
+        print::print_response(response).await;
 
         Ok(())
     }

--- a/bin/src/commands/run.rs
+++ b/bin/src/commands/run.rs
@@ -1,13 +1,15 @@
+mod print;
+
 use crate::commands::reqwest::Client;
 use crate::commands::RedeCommand;
 use crate::errors::ParsingError;
+use crate::standard;
 use crate::util::input_to_string;
-use crate::{standard, verbose};
 use clap::Args;
 use console::style;
-use log::{debug, info, trace};
+use log::{info, trace};
 use miette::{miette, LabeledSpan, Report};
-use rede_parser::{parse_request, Request};
+use rede_parser::parse_request;
 use std::time::Duration;
 
 /// Executes the provided HTTP request
@@ -42,50 +44,6 @@ impl RedeCommand for Command {
 
         standard!("{}", style(response).italic());
         Ok(())
-    }
-}
-
-impl Command {
-    fn print_request(&self, request: &Request) {
-        debug!("{request:?}");
-
-        standard!(
-            "{} Executing request {}\n",
-            style(">").bold().cyan(),
-            style(request.metadata.get("name").unwrap_or(&self.request)).yellow()
-        );
-
-        let query = if request.query_params.is_empty() {
-            String::new()
-        } else {
-            let query = request
-                .query_params
-                .iter()
-                .map(|(k, v)| format!("{k}={v}"))
-                .collect::<Vec<String>>()
-                .join("&");
-            format!("?{query}")
-        };
-
-        let url = format!("{}{}", request.url, query);
-
-        // TODO print each method in a different color
-        verbose!(
-            "{} {}",
-            style(request.method.as_str()).yellow(),
-            style(url).underlined().cyan()
-        );
-
-        // TODO use if_verbose! to omit this loop
-        for (header_key, header_value) in &request.headers {
-            verbose!(
-                "  - {} : {}",
-                header_key,
-                header_value.to_str().unwrap_or("<no ascii>")
-            );
-        }
-
-        verbose!("");
     }
 }
 

--- a/bin/src/commands/run/print.rs
+++ b/bin/src/commands/run/print.rs
@@ -39,8 +39,9 @@ impl super::Command {
         verbose!(
             "{} {}",
             style(request.method.as_str()).bold().yellow(),
-            style(url).underlined().cyan()
+            style(url).underlined().cyan(),
         );
+        verbose!("{:?}", request.http_version);
 
         // TODO use if_verbose! to omit this loop
         for (header_key, header_value) in &request.headers {

--- a/bin/src/commands/run/print.rs
+++ b/bin/src/commands/run/print.rs
@@ -1,6 +1,6 @@
 use crate::{standard, verbose};
 use console::{style, Style};
-use http::StatusCode;
+use http::{HeaderMap, StatusCode};
 use log::debug;
 use rede_parser::{Body, Request};
 use reqwest::Response;
@@ -45,16 +45,7 @@ impl super::Command {
         );
         verbose!("{:?}", request.http_version);
 
-        // TODO use if_verbose! to omit this loop
-        for (header_key, header_value) in &request.headers {
-            verbose!(
-                "  - {} : {}",
-                header_key,
-                header_value.to_str().unwrap_or("<no ascii>")
-            );
-        }
-
-        verbose!("");
+        print_headers(&request.headers);
 
         if let Some(mime) = request.body.mime() {
             verbose!("[{}]", style(mime).cyan());
@@ -98,6 +89,20 @@ pub(crate) fn print_response(response: &Response) {
         style(response.url()).underlined().blue()
     );
     verbose!("{:?}", response.version());
+
+    print_headers(response.headers());
+}
+
+fn print_headers(headers: &HeaderMap) {
+    // TODO use if_verbose! to omit this loop
+    for (header_key, header_value) in headers {
+        verbose!(
+            "  - {} : {}",
+            header_key,
+            header_value.to_str().unwrap_or("<no ascii>")
+        );
+    }
+    verbose!("");
 }
 
 fn status_color(status_code: StatusCode) -> Style {

--- a/bin/src/commands/run/print.rs
+++ b/bin/src/commands/run/print.rs
@@ -1,7 +1,9 @@
 use crate::{standard, verbose};
-use console::style;
+use console::{style, Style};
+use http::StatusCode;
 use log::debug;
 use rede_parser::{Body, Request};
+use reqwest::Response;
 
 impl super::Command {
     pub(crate) fn print_request(&self, request: &Request) {
@@ -77,4 +79,30 @@ impl super::Command {
             Body::None => {}
         }
     }
+}
+
+pub(crate) fn print_response(response: &Response) {
+    let status_color = status_color(response.status());
+
+    let output_arrows = status_color.apply_to("<<<");
+    verbose!(
+        "{} {} {}\n",
+        &output_arrows,
+        style("HTTP Response").bold(),
+        &output_arrows
+    );
+
+    verbose!("{}", status_color.apply_to(response.status()));
+}
+
+fn status_color(status_code: StatusCode) -> Style {
+    match status_code.as_u16() {
+        100..=199 => Style::new().blue(),
+        200..=299 => Style::new().green(),
+        300..=399 => Style::new().magenta(),
+        400..=499 => Style::new().yellow(),
+        500..=599 => Style::new().red(),
+        _ => Style::new(),
+    }
+    .bold()
 }

--- a/bin/src/commands/run/print.rs
+++ b/bin/src/commands/run/print.rs
@@ -1,0 +1,79 @@
+use crate::{standard, verbose};
+use console::style;
+use log::debug;
+use rede_parser::{Body, Request};
+
+impl super::Command {
+    pub(crate) fn print_request(&self, request: &Request) {
+        debug!("{request:?}");
+
+        standard!(
+            "{} Executing request {}\n",
+            style(">").bold().cyan(),
+            style(request.metadata.get("name").unwrap_or(&self.request)).yellow()
+        );
+
+        let output_arrows = style(">>>").bold().cyan();
+        verbose!(
+            "{} {} {}\n",
+            &output_arrows,
+            style("HTTP Request").bold(),
+            &output_arrows
+        );
+
+        let query = if request.query_params.is_empty() {
+            String::new()
+        } else {
+            let query = request
+                .query_params
+                .iter()
+                .map(|(k, v)| format!("{k}={v}"))
+                .collect::<Vec<String>>()
+                .join("&");
+            format!("?{query}")
+        };
+
+        let url = format!("{}{}", request.url, query);
+
+        // TODO print each method in a different color
+        verbose!(
+            "{} {}",
+            style(request.method.as_str()).bold().yellow(),
+            style(url).underlined().cyan()
+        );
+
+        // TODO use if_verbose! to omit this loop
+        for (header_key, header_value) in &request.headers {
+            verbose!(
+                "  - {} : {}",
+                header_key,
+                header_value.to_str().unwrap_or("<no ascii>")
+            );
+        }
+
+        verbose!("");
+
+        if let Some(mime) = request.body.mime() {
+            verbose!("[{}]", style(mime).blue());
+        }
+        match &request.body {
+            Body::Raw { content, .. } => verbose!("{content}\n"),
+            Body::Binary { path, .. } => verbose!("    @{path}\n"),
+            Body::XFormUrlEncoded(map) => {
+                let query = map
+                    .iter()
+                    .map(|(k, v)| format!("{k}={v}"))
+                    .collect::<Vec<String>>()
+                    .join(&style("&").blue().to_string());
+                verbose!("{query}\n");
+            }
+            Body::FormData(form) => {
+                for (k, v) in form {
+                    verbose!("{}: {}", style(k).blue(), v);
+                }
+                verbose!("");
+            }
+            Body::None => {}
+        }
+    }
+}

--- a/bin/src/commands/run/print.rs
+++ b/bin/src/commands/run/print.rs
@@ -15,7 +15,7 @@ impl super::Command {
             style(request.metadata.get("name").unwrap_or(&self.request)).yellow()
         );
 
-        let output_arrows = style(">>>").bold().cyan();
+        let output_arrows = style(">>>").bold().blue();
         verbose!(
             "{} {} {}\n",
             &output_arrows,
@@ -41,7 +41,7 @@ impl super::Command {
         verbose!(
             "{} {}",
             style(request.method.as_str()).bold().yellow(),
-            style(url).underlined().cyan(),
+            style(url).underlined().blue(),
         );
         verbose!("{:?}", request.http_version);
 
@@ -57,7 +57,7 @@ impl super::Command {
         verbose!("");
 
         if let Some(mime) = request.body.mime() {
-            verbose!("[{}]", style(mime).blue());
+            verbose!("[{}]", style(mime).cyan());
         }
         match &request.body {
             Body::Raw { content, .. } => verbose!("{content}\n"),
@@ -92,12 +92,17 @@ pub(crate) fn print_response(response: &Response) {
         &output_arrows
     );
 
-    verbose!("{}", status_color.apply_to(response.status()));
+    verbose!(
+        "{} - {}",
+        status_color.apply_to(response.status()),
+        style(response.url()).underlined().blue()
+    );
+    verbose!("{:?}", response.version());
 }
 
 fn status_color(status_code: StatusCode) -> Style {
     match status_code.as_u16() {
-        100..=199 => Style::new().blue(),
+        100..=199 => Style::new().cyan(),
         200..=299 => Style::new().green(),
         300..=399 => Style::new().magenta(),
         400..=499 => Style::new().yellow(),

--- a/bin/src/errors.rs
+++ b/bin/src/errors.rs
@@ -36,7 +36,7 @@ pub enum RequestError<E: Error> {
     #[error(transparent)]
     #[diagnostic(code = "failed connection")]
     FailedConnection(E),
-    #[error("resulting url is not correct ({})", style(url).underlined().blue())]
+    #[error("resulting url is not correct ({})", style(url).underlined().cyan())]
     #[diagnostic(code("invalid url"))]
     InvalidUrl {
         url: String,

--- a/bin/tests/run.rs
+++ b/bin/tests/run.rs
@@ -13,6 +13,7 @@ macro_rules! test_req {
             let file = format!("tests/inputs/{}", stringify!($file));
             Command::cargo_bin("rede")
                 .unwrap()
+                .arg("--no-color")
                 .arg("run")
                 $(.arg($arg))*
                 .arg(file)

--- a/bin/tests/run.rs
+++ b/bin/tests/run.rs
@@ -15,6 +15,7 @@ macro_rules! test_req {
                 .unwrap()
                 .arg("--no-color")
                 .arg("run")
+                .arg("--pretty-print=false")
                 $(.arg($arg))*
                 .arg(file)
                 .assert()


### PR DESCRIPTION
Adds all the printing for incoming responses. By default, just the body.
With verbose... a whole plethora of beautiful and colorful messages. Should this really be the default?

_I will end up changing verbosity to levels right? Yay! More work_

- **feat: print request body**
- **feat: print http version**
- **feat: print response status code**
- **feat: print response url and version**
- **feat: print response headers**
- **feat: print body**
