### PR TITLE
feat: print status as fallback when no body

### DIFF
--- a/bin/src/commands/run/print.rs
+++ b/bin/src/commands/run/print.rs
@@ -83,11 +83,8 @@ impl super::Command {
             &output_arrows
         );
 
-        verbose!(
-            "{} - {}",
-            status_color.apply_to(response.status()),
-            style(response.url()).underlined().blue()
-        );
+        let status = status_color.apply_to(response.status());
+        verbose!("{status} - {}", style(response.url()).underlined().blue());
         verbose!("{:?}", response.version());
 
         print_headers(response.headers());
@@ -108,6 +105,10 @@ impl super::Command {
                 standard!("{}", to_string_pretty(&json).unwrap());
                 return;
             }
+        }
+
+        if body.is_empty() {
+            standard!(below[Verbose] "{status}");
         }
         standard!("{body}");
     }

--- a/bin/tests/inputs/not_found.toml
+++ b/bin/tests/inputs/not_found.toml
@@ -1,0 +1,3 @@
+[http]
+method = "GET"
+url = "http://localhost:8080/api/not_found"

--- a/bin/tests/run.rs
+++ b/bin/tests/run.rs
@@ -35,15 +35,12 @@ macro_rules! test_request {
 }
 
 macro_rules! test_error {
-    // Runs the test using the file matching the test name
     ($(#[$m:meta])*$name:ident $(, $arg:literal)* -> $assert:expr) => {
         test_req!($(#[$m])*$name, failure, stderr, <$name> $($arg),* -> $assert);
     };
-    // Runs the test using the `get_simple` file, for test not dependent on the request file
     ($(#[$m:meta])*$name:ident <> $($arg:literal),* -> $assert:expr) => {
         test_req!($(#[$m])*$name, failure, stderr, <get_simple> $($arg),* -> $assert);
     };
-    // Runs the test using the given file
     ($(#[$m:meta])*$name:ident <$file:ident> $($arg:literal),* -> $assert:expr) => {
         test_req!($(#[$m])*$name, failure, stderr, <$file> $($arg),* -> $assert);
     };
@@ -58,6 +55,7 @@ test_request!(body_binary -> contains(r#""size":8"#).and(contains(r#""content-ty
 test_request!(body_form_data -> contains(r#""text":"agarimo""#).and(contains(r#""binary_size":8"#).and(contains("multipart/form-data; boundary="))));
 test_request!(body_form_url_encoded -> contains(r#""anime":"Evangelion""#).and(contains(r#""content-type":"application/x-www-form-urlencoded""#)));
 test_request!(override_content_type -> contains(r#""content-type":"application/json""#));
+test_request!(status_if_no_body<not_found> -> contains("404"));
 // todo -no-redirect, requires --verbose
 
 test_error!(missing_file -> contains("invalid [REQUEST]").and(contains("No such file or directory")));


### PR DESCRIPTION
If no body is returned in the response, print the status as fallback in standard verbose mode.

_Always giving the user some kind of feedback is now a feat, huh?_
