### PR TITLE
doc: improve help for release

### DIFF
--- a/bin/src/commands.rs
+++ b/bin/src/commands.rs
@@ -9,7 +9,14 @@ mod reqwest;
 mod run;
 
 #[derive(Debug, Parser)]
-#[command(name = "rede", term_width = 100, about, version)]
+#[command(
+    name = "rede",
+    about,
+    infer_long_args = true,
+    infer_subcommands = true,
+    term_width = 100,
+    version
+)]
 pub(crate) struct Cli {
     #[command(subcommand)]
     command: Command,

--- a/bin/src/commands.rs
+++ b/bin/src/commands.rs
@@ -12,6 +12,7 @@ mod run;
 #[command(
     name = "rede",
     about,
+    next_help_heading = "Global options",
     infer_long_args = true,
     infer_subcommands = true,
     term_width = 100,
@@ -21,13 +22,13 @@ pub(crate) struct Cli {
     #[command(subcommand)]
     command: Command,
     /// Enables all printing messages
-    #[arg(long, conflicts_with = "quiet")]
+    #[arg(long, global = true, conflicts_with = "quiet")]
     verbose: bool,
     /// Disables all printing messages
-    #[arg(long)]
+    #[arg(long, global = true)]
     quiet: bool,
     /// Disables output coloring
-    #[arg(long)]
+    #[arg(long, global = true)]
     no_color: bool,
 }
 

--- a/bin/src/commands/run.rs
+++ b/bin/src/commands/run.rs
@@ -20,10 +20,11 @@ pub struct Command {
     /// Specifies if formatting applied should be applied to response body, by default is true
     #[arg(
         long,
-        default_missing_value("true"),
-        default_value("true"),
+        value_name = "true|false",
+        default_missing_value ="true",
+        default_value = "true",
         num_args(0..=1),
-        require_equals(true),
+        require_equals = true,
         action = ArgAction::Set,
     )]
     pretty_print: bool,


### PR DESCRIPTION
Now commands and arguments can be inferred from their substrings. Yes, `rede r` will now run `rede run`.

And now the root options are global. Yes, `rede r --q` will now run the request in quiet mode.

Oh, some doc improvements.

_this could have been the PR for the first release but I just decided to something extra because I'm stupid_


- **feat: infering**
- **feat: make printing arguments global**
- **doc: improve rede run help**
