### PR TITLE
feat: add variables

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -10,7 +10,7 @@
 - [Request DSL](./reference_guide/request_dsl.md)
   - [Body](./reference_guide/request_dsl/body.md)
   - [Input_parameters]()
-  - [Placeholders and variables]()
+  - [Placeholders](./reference_guide/request_dsl/placeholders.md)
 - [Command Line Interface](./reference_guide/command_line_interface.md)
   - [run](reference_guide/command_line_interface/run.md)
   - [example](reference_guide/command_line_interface/example.md)

--- a/book/src/reference_guide/request_dsl.md
+++ b/book/src/reference_guide/request_dsl.md
@@ -68,6 +68,7 @@ _warning: some common leaders like `Host` and `Content-Type` will be autogenerat
 option to disable this autogeneration_
 
 ## [query_params]
+
 This table is **free**. There's no predefined keys but the values can't be of type datetime
 or tables. Arrays are supported and will be sent in the request as a comma separated list of
 the values.
@@ -93,6 +94,18 @@ body.binary = "./doc/project_v2_final_final.pdf"
 [body.x-www-form-urlencoded]
 name = "Feldespato"
 location = "unknown"
+```
+
+## [variables]
+This table is **free**. There's no predefined keys but the values can't be of type datetime
+or tables. Arrays are supported and will be sent in the request as a comma separated list of
+the values.
+
+Variables serve to set a value to replace **placeholders** ([see](./request_dsl/placeholders.md)).
+
+```toml
+host = "192.0.0.1"
+name = "Vin"
 ```
 
 ## [metadata]

--- a/book/src/reference_guide/request_dsl/placeholders.md
+++ b/book/src/reference_guide/request_dsl/placeholders.md
@@ -1,0 +1,12 @@
+# Placeholders
+
+Placeholders are strings wrapped in double braces, like `{{this}}`. They can be the whole value
+of a string or can be a substring, for example: `{{host}}/api/{{version}}/hello`.
+
+Placeholders can be given a value through different resolvers. These resolvers have a defined
+order and the first providing a value will be the one that is used. If no resolver has a value
+for the placeholder then the user will be prompted to resolve it.
+
+The order of resolution is:
+1. [Variables](#variables), these are defined in a [standard table](../request_dsl.md#variables)
+similar to query params or headers, but this one is only aimed to provide values for placeholders.

--- a/docs/schema/schema_v0.1.toml
+++ b/docs/schema/schema_v0.1.toml
@@ -59,10 +59,10 @@ _key = "string"
 [query_params]
 _key = ["string", "integer", "float", "boolean", "array"]
 
-####### The path params table defines the value for segment paths enclosed in `{{name}}`, overrides env values
+####### The variables table allows to define values for placeholders
 
-[path_params]
-_key = ["string", "integer", "float", "boolean"]
+[variables]
+_key = ["string", "integer", "float", "boolean", "array"]
 
 ####### Defines the body that will be sent with the request
 

--- a/parser/src/request.rs
+++ b/parser/src/request.rs
@@ -17,8 +17,8 @@ pub struct Request {
     pub metadata: HashMap<String, String>,
     pub headers: HeaderMap,
     pub query_params: Vec<(String, String)>,
-    pub path_params: HashMap<String, String>,
     pub body: Body,
+    pub variables: HashMap<String, String>,
 }
 
 impl TryFrom<Schema> for Request {
@@ -32,7 +32,7 @@ impl TryFrom<Schema> for Request {
             metadata: schema.metadata.into_map(),
             headers: schema.headers,
             query_params: schema.query_params.into_pairs(),
-            path_params: schema.path_params.into_map(),
+            variables: schema.variables.into_map(),
             body: schema.body.into(),
         })
     }
@@ -65,8 +65,11 @@ mod test {
             PrimitiveArray::Multiple(vec![Primitive::Str("s".to_string()), Primitive::Int(1)]),
         );
 
-        let mut path_params = HashMap::new();
-        path_params.insert("pp".to_string(), Primitive::Str("value".to_string()));
+        let mut variables = HashMap::new();
+        variables.insert(
+            "pp".to_string(),
+            PrimitiveArray::Single(Primitive::Str("value".to_string())),
+        );
 
         let body = schema::Body::Binary("path".to_string());
 
@@ -79,7 +82,7 @@ mod test {
             headers,
             metadata: Table::new(metadata),
             query_params: Table::new(query_params),
-            path_params: Table::new(path_params),
+            variables: Table::new(variables),
             body,
         };
 
@@ -96,7 +99,7 @@ mod test {
                 ("qp".to_string(), "1".to_string())
             ]
         );
-        assert_eq!(request.path_params["pp"], "value");
+        assert_eq!(request.variables["pp"], "value");
         assert_eq!(
             request.body,
             Body::Binary {

--- a/parser/src/schema.rs
+++ b/parser/src/schema.rs
@@ -6,7 +6,7 @@ use serde::Deserialize;
 pub(crate) use body::Body;
 
 use crate::error::Error;
-use crate::schema::table::PrimitiveArrTable;
+use crate::schema::table::PrimitiveTable;
 
 mod body;
 pub(crate) mod table;
@@ -18,15 +18,15 @@ pub(crate) mod types;
 pub(crate) struct Schema {
     pub http: Http,
     #[serde(default)]
-    pub metadata: PrimitiveArrTable,
+    pub metadata: PrimitiveTable,
     #[serde(with = "http_serde::header_map", default)]
     pub headers: HeaderMap,
     #[serde(alias = "queryparams", alias = "query-params", default)]
-    pub query_params: PrimitiveArrTable,
+    pub query_params: PrimitiveTable,
     #[serde(default)]
     pub body: Body,
     #[serde(default)]
-    pub variables: PrimitiveArrTable,
+    pub variables: PrimitiveTable,
 }
 
 #[derive(Deserialize)]

--- a/parser/src/schema/body.rs
+++ b/parser/src/schema/body.rs
@@ -1,5 +1,5 @@
 use crate::body::Body as PublicBody;
-use crate::schema::table::{FormDataTable, PrimitiveArrTable, Transform};
+use crate::schema::table::{FormDataTable, PrimitiveTable, Transform};
 use crate::schema::types::PrimitiveArray;
 use serde::Deserialize;
 
@@ -24,7 +24,7 @@ pub(crate) enum Body {
         alias = "form_urlencoded",
         alias = "form-urlencoded"
     )]
-    XFormUrlEncoded(PrimitiveArrTable),
+    XFormUrlEncoded(PrimitiveTable),
 }
 
 #[derive(Debug, Deserialize, PartialEq)]

--- a/parser/src/schema/table.rs
+++ b/parser/src/schema/table.rs
@@ -3,14 +3,13 @@ use std::collections::HashMap;
 use std::ops::Index;
 
 use crate::schema::body::FormDataValue;
-use crate::schema::types::{Primitive, PrimitiveArray};
+use crate::schema::types::PrimitiveArray;
 use serde::Deserialize;
 
 /// Newtype implementation to wrap TOML tables where the set of keys can be free
 #[derive(Debug, Deserialize, PartialEq)]
 pub(crate) struct Table<V>(pub(crate) HashMap<String, V>);
 
-pub type PrimitiveTable = Table<Primitive>;
 pub type PrimitiveArrTable = Table<PrimitiveArray>;
 pub type FormDataTable = Table<FormDataValue>;
 

--- a/parser/src/schema/table.rs
+++ b/parser/src/schema/table.rs
@@ -10,7 +10,7 @@ use serde::Deserialize;
 #[derive(Debug, Deserialize, PartialEq)]
 pub(crate) struct Table<V>(pub(crate) HashMap<String, V>);
 
-pub type PrimitiveArrTable = Table<PrimitiveArray>;
+pub type PrimitiveTable = Table<PrimitiveArray>;
 pub type FormDataTable = Table<FormDataValue>;
 
 impl<V> Index<&str> for Table<V> {
@@ -58,7 +58,7 @@ where
     }
 }
 
-impl PrimitiveArrTable {
+impl PrimitiveTable {
     pub(crate) fn into_pairs(self) -> Vec<(String, String)> {
         let mut vec = Vec::new();
         for (key, val) in self {
@@ -108,7 +108,7 @@ mod test {
         assert_eq!(map["array"], "one,2");
     }
 
-    fn new_test_table() -> PrimitiveArrTable {
+    fn new_test_table() -> PrimitiveTable {
         let string = r#"
         string = "value"
         integer = 10


### PR DESCRIPTION
Replace the old pathparams with variables.

_i don't know why it didn't cross my mind that the pathparams was irrelevant_

- **feat: convert pathparams a variables**
- **refactor: rename primitive array table**
- **doc: variables**
