### PR TITLE
feat: parse input parameters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: check
+
   test:
     name: Test
     runs-on: ubuntu-latest
@@ -54,6 +55,13 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
+
+      - name: Test rede_parser features
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: -p rede_parser --all-features
+
   lints:
     name: Lint
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -984,25 +984,13 @@ dependencies = [
  "miette",
  "mime",
  "predicates",
- "rede_parser 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rede_parser 0.1.4",
  "reqwest",
  "serde_json",
  "thiserror",
  "tokio",
  "tokio-util",
  "url",
-]
-
-[[package]]
-name = "rede_parser"
-version = "0.1.4"
-dependencies = [
- "http",
- "http-serde",
- "mime",
- "serde",
- "thiserror",
- "toml",
 ]
 
 [[package]]
@@ -1020,12 +1008,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "rede_parser"
+version = "0.2.0"
+dependencies = [
+ "http",
+ "http-serde",
+ "mime",
+ "serde",
+ "thiserror",
+ "toml",
+]
+
+[[package]]
 name = "rede_placeholders"
 version = "0.1.0"
 dependencies = [
  "http",
  "mime",
- "rede_parser 0.1.4",
+ "rede_parser 0.2.0",
  "regex",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1025,7 +1025,7 @@ version = "0.1.0"
 dependencies = [
  "http",
  "mime",
- "rede_parser 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rede_parser 0.1.4",
  "regex",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1025,7 +1025,7 @@ version = "0.1.0"
 dependencies = [
  "http",
  "mime",
- "rede_parser 0.1.4",
+ "rede_parser 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex",
 ]
 

--- a/Makefile
+++ b/Makefile
@@ -4,4 +4,8 @@ it_test:
 serve_doc:
 	cd book && mdbook serve --open
 
-.PHONY: it_test, serve_doc
+test:
+	cargo test
+	cargo test -p rede_parser --all-features
+
+.PHONY: it_test, serve_doc, test

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -9,7 +9,7 @@
 # Reference Guide
 - [Request DSL](./reference_guide/request_dsl.md)
   - [Body](./reference_guide/request_dsl/body.md)
-  - [Input_parameters]()
+  - [Input parameters](./reference_guide/request_dsl/input_parameters.md)
   - [Placeholders](./reference_guide/request_dsl/placeholders.md)
 - [Command Line Interface](./reference_guide/command_line_interface.md)
   - [run](reference_guide/command_line_interface/run.md)

--- a/book/src/reference_guide/request_dsl.md
+++ b/book/src/reference_guide/request_dsl.md
@@ -108,6 +108,20 @@ host = "192.0.0.1"
 name = "Vin"
 ```
 
+## [input_params]
+The input params table can have any key desired by the user, but they must be tables. These tables
+can be empty or can contain the following keys:
+- `hint`, _string_. A hint to the user when prompted to provide a value.
+- `default`, _string_. The default value to be used if the user doesn't provide one.
+
+```toml
+[input_params]
+host = { hint = "The host of the API", default = "127.0.0.1" }
+id = { hint = "The ID of the resource" }
+```
+
+To know how the input parameters are used, refer to the [input parameters page](./request_dsl/input_parameters.md).
+
 ## [metadata]
 
 This table is **free** but the values must be one of the primitive values (_string_, _integer_,

--- a/book/src/reference_guide/request_dsl/input_parameters.md
+++ b/book/src/reference_guide/request_dsl/input_parameters.md
@@ -1,0 +1,39 @@
+# Input parameters
+
+`rede` requests can have input parameters that can be used to customize the request execution based on
+inputs of the user in execution time. These parameters are defined in the request file and can be used in the URL,
+headers, query parameters, and body as [placeholders](placeholders.md).
+
+The input parameters are defined in a table named `input_params` and can have any key desired by the user but only
+those present as placeholder in the request will be used in the request. Otherwise the user will be prompted but
+the value won't be used.
+
+The input parameters can be defined with the following optional properties:
+- `hint`. A hint to the user when prompted to provide a value.
+- `default`. The default value to be used if the user doesn't provide one.
+
+## Example
+
+We have the following request
+
+```toml
+url = "{{host}}/api/{{version}}/user/{{id}}"
+
+[input_params]
+host = { default = "127.0.0.1" }
+version = { hint = "The version of the API", default = "v1" }
+id = { hint = "The ID of the resource" }
+```
+
+When running this request, the user will be prompted to provide the values for `host`, `version`, and `id`. For those
+inputs with a hint, it will be shown to the user. The default value will also be printed so the user will know what
+value will be used if they don't provide one. If the user doesn't provide a value for the `id`, which doesn't have a
+default value, the next option for the placeholder will be used ([see](placeholders.md#resolvers)).
+
+Finishing the example, imagine that the user provided the following values:
+- `host`: `https://test.api.example.com`
+- `version`: _empty_ (so, it will use the default value `v1`)
+- `id`: `123`
+
+Then this user will be executing the request to `https://test.api.example.com/api/v1/user/123`.
+

--- a/book/src/reference_guide/request_dsl/placeholders.md
+++ b/book/src/reference_guide/request_dsl/placeholders.md
@@ -3,10 +3,14 @@
 Placeholders are strings wrapped in double braces, like `{{this}}`. They can be the whole value
 of a string or can be a substring, for example: `{{host}}/api/{{version}}/hello`.
 
+## Resolvers
+
 Placeholders can be given a value through different resolvers. These resolvers have a defined
 order and the first providing a value will be the one that is used. If no resolver has a value
 for the placeholder then the user will be prompted to resolve it.
 
 The order of resolution is:
-1. [Variables](#variables), these are defined in a [standard table](../request_dsl.md#variables)
+1. [Input parameters](#input-parameters), these will be input by the user when the request is executed. If the
+user doesn't provide a value and the input parameter has a default, that default will be used.
+2. [Variables](#variables), these are defined in a [standard table](../request_dsl.md#variables)
 similar to query params or headers, but this one is only aimed to provide values for placeholders.

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -14,6 +14,9 @@ documentation = "https://docs.rs/rede_parser"
 keywords = [ "parser", "rede", "toml", "http" ]
 readme = "./README.md"
 
+[features]
+input_params = []
+
 [dependencies]
 http.workspace = true
 mime.workspace = true

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rede_parser"
-version = "0.1.4"
+version = "0.2.0"
 edition.workspace = true
 
 authors.workspace = true

--- a/parser/src/input_param.rs
+++ b/parser/src/input_param.rs
@@ -1,5 +1,6 @@
 use serde::Deserialize;
 
+// todo: doc
 #[derive(Debug, Default, Deserialize, PartialEq)]
 pub struct InputParam {
     pub hint: Option<String>,

--- a/parser/src/input_param.rs
+++ b/parser/src/input_param.rs
@@ -1,9 +1,11 @@
 use serde::Deserialize;
 
-// todo: doc
+/// Contains the different properties that can be defined for an input parameter.
 #[derive(Debug, Default, Deserialize, PartialEq)]
 pub struct InputParam {
+    /// Hint to provide to the user when asking for the input
     pub hint: Option<String>,
+    /// Default value to use if the user does not provide any input
     pub default: Option<String>,
 }
 

--- a/parser/src/input_param.rs
+++ b/parser/src/input_param.rs
@@ -1,0 +1,34 @@
+use serde::Deserialize;
+
+#[derive(Debug, Default, Deserialize, PartialEq)]
+pub struct InputParam {
+    pub hint: Option<String>,
+    pub default: Option<String>,
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn deserialize() {
+        let toml = r#"
+            hint = "hint"
+            default = "default"
+        "#;
+        let input_param: InputParam = toml::from_str(toml).unwrap();
+        assert_eq!(
+            input_param,
+            InputParam {
+                hint: Some("hint".to_string()),
+                default: Some("default".to_string()),
+            }
+        );
+    }
+
+    #[test]
+    fn deserialize_empty() {
+        let input_param: InputParam = toml::from_str("").unwrap();
+        assert_eq!(input_param, InputParam::default());
+    }
+}

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -48,6 +48,7 @@
 pub mod body;
 
 mod error;
+mod input_param;
 mod request;
 mod schema;
 
@@ -58,6 +59,8 @@ use std::str::FromStr;
 pub use body::Body;
 #[doc(inline)]
 pub use error::Error;
+#[doc(inline)]
+pub use input_param::InputParam;
 #[doc(inline)]
 pub use request::Request;
 

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -48,9 +48,11 @@
 pub mod body;
 
 mod error;
-mod input_param;
 mod request;
 mod schema;
+
+#[cfg(feature = "input_params")]
+mod input_param;
 
 use crate::schema::Schema;
 use std::str::FromStr;
@@ -60,9 +62,11 @@ pub use body::Body;
 #[doc(inline)]
 pub use error::Error;
 #[doc(inline)]
-pub use input_param::InputParam;
-#[doc(inline)]
 pub use request::Request;
+
+#[cfg(feature = "input_params")]
+#[doc(inline)]
+pub use input_param::InputParam;
 
 /// Attempts to parse the given string into an HTTP request.
 ///

--- a/parser/src/request.rs
+++ b/parser/src/request.rs
@@ -6,6 +6,7 @@ use crate::body::Body;
 use crate::error::Error;
 use crate::schema::table::Transform;
 use crate::schema::Schema;
+use crate::InputParam;
 
 /// Representation of a rede HTTP request. Contains all the supported content by the current schema
 /// to allow the creation and dispatching of the HTTP request with the command-line interface.
@@ -19,6 +20,7 @@ pub struct Request {
     pub query_params: Vec<(String, String)>,
     pub body: Body,
     pub variables: HashMap<String, String>,
+    pub input_params: HashMap<String, InputParam>,
 }
 
 impl TryFrom<Schema> for Request {
@@ -34,6 +36,7 @@ impl TryFrom<Schema> for Request {
             query_params: schema.query_params.into_pairs(),
             variables: schema.variables.into_map(),
             body: schema.body.into(),
+            input_params: schema.input_params.0,
         })
     }
 }
@@ -76,7 +79,7 @@ mod test {
             "ip".to_string(),
             InputParam {
                 hint: Some("hint".to_string()),
-                default: Some("default".to_string()),
+                default: Some("127.0.0.1".to_string()),
             },
         );
 
@@ -115,6 +118,13 @@ mod test {
             Body::Binary {
                 path: "path".to_string(),
                 mime: mime::APPLICATION_OCTET_STREAM,
+            }
+        );
+        assert_eq!(
+            request.input_params["ip"],
+            InputParam {
+                hint: Some("hint".to_string()),
+                default: Some("127.0.0.1".to_string())
             }
         );
     }

--- a/parser/src/request.rs
+++ b/parser/src/request.rs
@@ -14,16 +14,25 @@ use crate::InputParam;
 /// to allow the creation and dispatching of the HTTP request with the command-line interface.
 #[derive(Debug)]
 pub struct Request {
+    /// HTTP method of the request
     pub method: Method,
+    /// URL of the request
     pub url: String,
+    /// HTTP version of the request
     pub http_version: Version,
+    /// Metadata of the request file
     pub metadata: HashMap<String, String>,
+    /// Headers of the request
     pub headers: HeaderMap,
+    /// Query parameters of the request
     pub query_params: Vec<(String, String)>,
+    /// Body of the request
     pub body: Body,
+    /// Variables to provide values for placeholders in the request
     pub variables: HashMap<String, String>,
 
     #[cfg(feature = "input_params")]
+    /// Keys of placeholders to ask the user for input
     pub input_params: HashMap<String, InputParam>,
 }
 

--- a/parser/src/request.rs
+++ b/parser/src/request.rs
@@ -71,6 +71,15 @@ mod test {
             PrimitiveArray::Single(Primitive::Str("value".to_string())),
         );
 
+        let mut input_params = HashMap::new();
+        input_params.insert(
+            "ip".to_string(),
+            schema::InputParam {
+                hint: Some("hint".to_string()),
+                default: Some("default".to_string()),
+            },
+        );
+
         let body = schema::Body::Binary("path".to_string());
 
         let schema = Schema {
@@ -84,6 +93,7 @@ mod test {
             query_params: Table::new(query_params),
             variables: Table::new(variables),
             body,
+            input_params: Table::new(input_params),
         };
 
         let request = Request::try_from(schema).unwrap();

--- a/parser/src/request.rs
+++ b/parser/src/request.rs
@@ -41,10 +41,10 @@ impl TryFrom<Schema> for Request {
 #[cfg(test)]
 mod test {
     use crate::body::Body;
-    use crate::schema;
     use crate::schema::table::Table;
     use crate::schema::types::{Primitive, PrimitiveArray};
     use crate::schema::{Http, Schema};
+    use crate::{schema, InputParam};
 
     use super::*;
 
@@ -74,7 +74,7 @@ mod test {
         let mut input_params = HashMap::new();
         input_params.insert(
             "ip".to_string(),
-            schema::InputParam {
+            InputParam {
                 hint: Some("hint".to_string()),
                 default: Some("default".to_string()),
             },

--- a/parser/src/schema.rs
+++ b/parser/src/schema.rs
@@ -42,12 +42,6 @@ pub(crate) struct Http {
     pub version: Version,
 }
 
-#[derive(Debug, Default, Deserialize, PartialEq)]
-pub(crate) struct InputParam {
-    pub hint: Option<String>,
-    pub default: Option<String>,
-}
-
 impl FromStr for Schema {
     type Err = Error;
 
@@ -60,6 +54,7 @@ impl FromStr for Schema {
 #[cfg(test)]
 mod test {
     use crate::schema::types::{Primitive, PrimitiveArray};
+    use crate::InputParam;
 
     use super::*;
 
@@ -100,11 +95,9 @@ mod test {
 
     [input-params]
     host = { hint = "Host name", default = "localhost" }
+    no-default = { hint = "This has no default value" }
 
     [input-params.empty]
-
-    [input-params.no-default]
-    hint = "Port number"
     "#;
 
     #[test]
@@ -191,7 +184,7 @@ mod test {
         );
         assert_eq!(
             schema.input_params.0["no-default"].hint,
-            Some("Port number".to_string())
+            Some("This has no default value".to_string())
         );
     }
 

--- a/parser/src/schema/table.rs
+++ b/parser/src/schema/table.rs
@@ -4,7 +4,7 @@ use std::ops::Index;
 
 use crate::schema::body::FormDataValue;
 use crate::schema::types::PrimitiveArray;
-use crate::schema::InputParam;
+use crate::InputParam;
 use serde::Deserialize;
 
 /// Newtype implementation to wrap TOML tables where the set of keys can be free

--- a/parser/src/schema/table.rs
+++ b/parser/src/schema/table.rs
@@ -4,8 +4,10 @@ use std::ops::Index;
 
 use crate::schema::body::FormDataValue;
 use crate::schema::types::PrimitiveArray;
-use crate::InputParam;
 use serde::Deserialize;
+
+#[cfg(feature = "input_params")]
+use crate::InputParam;
 
 /// Newtype implementation to wrap TOML tables where the set of keys can be free
 #[derive(Debug, Deserialize, PartialEq)]
@@ -13,6 +15,8 @@ pub(crate) struct Table<V>(pub(crate) HashMap<String, V>);
 
 pub type PrimitiveTable = Table<PrimitiveArray>;
 pub type FormDataTable = Table<FormDataValue>;
+
+#[cfg(feature = "input_params")]
 pub type InputParamsTable = Table<InputParam>;
 
 impl<V> Index<&str> for Table<V> {

--- a/parser/src/schema/table.rs
+++ b/parser/src/schema/table.rs
@@ -4,6 +4,7 @@ use std::ops::Index;
 
 use crate::schema::body::FormDataValue;
 use crate::schema::types::PrimitiveArray;
+use crate::schema::InputParam;
 use serde::Deserialize;
 
 /// Newtype implementation to wrap TOML tables where the set of keys can be free
@@ -12,6 +13,7 @@ pub(crate) struct Table<V>(pub(crate) HashMap<String, V>);
 
 pub type PrimitiveTable = Table<PrimitiveArray>;
 pub type FormDataTable = Table<FormDataValue>;
+pub type InputParamsTable = Table<InputParam>;
 
 impl<V> Index<&str> for Table<V> {
     type Output = V;

--- a/placeholders/Cargo.toml
+++ b/placeholders/Cargo.toml
@@ -15,8 +15,8 @@ keywords = [ "rede", "placeholder", "search", "replace" ]
 readme = "./README.md"
 
 [dependencies]
-rede_parser = "0.1.4"
-#rede_parser = { path = "../parser" }
+#rede_parser = "0.1.4"
+rede_parser = { path = "../parser", default-features = false }
 
 regex = "1.10.4" # todo remove
 

--- a/placeholders/Cargo.toml
+++ b/placeholders/Cargo.toml
@@ -15,7 +15,8 @@ keywords = [ "rede", "placeholder", "search", "replace" ]
 readme = "./README.md"
 
 [dependencies]
-rede_parser = { path = "../parser" }
+rede_parser = "0.1.4"
+#rede_parser = { path = "../parser" }
 
 regex = "1.10.4" # todo remove
 

--- a/placeholders/src/placeholders.rs
+++ b/placeholders/src/placeholders.rs
@@ -158,7 +158,7 @@ mod test {
             metadata: Default::default(),
             headers,
             query_params,
-            variables: HashMap::new(),
+            path_params: HashMap::new(),
             body: Body::Raw {
                 content: r#"{"name":"{{name}}","genre":"{{genre}}"}"#.to_string(),
                 mime: mime::APPLICATION_JSON,

--- a/placeholders/src/placeholders.rs
+++ b/placeholders/src/placeholders.rs
@@ -158,7 +158,7 @@ mod test {
             metadata: Default::default(),
             headers,
             query_params,
-            path_params: HashMap::new(),
+            variables: HashMap::new(),
             body: Body::Raw {
                 content: r#"{"name":"{{name}}","genre":"{{genre}}"}"#.to_string(),
                 mime: mime::APPLICATION_JSON,


### PR DESCRIPTION
Adds the new `input_params`. Allowing to parse the input parameters in the request
and provide it in the `Request` entity.

- **feat: deserialize input params**
- **refactor: extract input param**
- **feat: add input params to request**
- **feat: hide input_params behind feature**
- **doc: input parameters**
- **chore: bump parser version**
