### PR TITLE
refactor: extract schema crate

### DIFF
--- a/.github/drafts/base.yml
+++ b/.github/drafts/base.yml
@@ -47,6 +47,9 @@ autolabeler:
   - label: 'placeholders'
     files:
       - 'placeholders/**'
+  - label: 'schema'
+    files:
+      - 'schema/**'
   - label: 'breaking-change'
     branch:
       - '/.*!:.*/'

--- a/.github/drafts/schema.yml
+++ b/.github/drafts/schema.yml
@@ -1,0 +1,6 @@
+_extends: rede:.github/drafts/base.yml
+name-template: 'rede_schema $RESOLVED_VERSION'
+tag-template: 'schema_v$RESOLVED_VERSION'
+tag-prefix: 'schema_v'
+include-paths:
+  - "schema/"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,4 @@
 name: Rust CI
-
 permissions:
   contents: read
 
@@ -68,6 +67,7 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
+
       - name: Install stable toolchain
         uses: actions-rs/toolchain@v1
         with:
@@ -75,12 +75,13 @@ jobs:
           toolchain: stable
           override: true
           components: rustfmt, clippy
+      
       - name: Run cargo fmt
         uses: actions-rs/cargo@v1
         with:
           command: fmt
           args: --all -- --check
-
+      
       - name: Run cargo clippy
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/publish_schema.yml
+++ b/.github/workflows/publish_schema.yml
@@ -1,0 +1,24 @@
+name: Publish rede_schema
+
+on:
+  push:
+    tags:
+      - 'schema_v*'
+  workflow_dispatch:
+
+jobs:
+  publish:
+    name: Publish
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - run: cargo publish --token ${CRATES_TOKEN} -p rede_schema
+        env:
+          CRATES_TOKEN: ${{ secrets.CRATES_TOKEN }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -21,6 +21,9 @@ jobs:
       - name: Changes on placeholders
         if: contains(github.event.pull_request.labels.*.name, 'placeholders') || github.event_name == 'workflow_dispatch'
         run: echo "RD_CONFIG_NAME=drafts/placeholders.yml" >> $GITHUB_ENV
+      - name: Changes on schema
+        if: contains(github.event.pull_request.labels.*.name, 'schema') || github.event_name == 'workflow_dispatch'
+        run: echo "RD_CONFIG_NAME=drafts/schema.yml" >> $GITHUB_ENV
     outputs:
       config-name: ${{ env.RD_CONFIG_NAME }}
   update_release_draft:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1048,6 +1048,7 @@ name = "rede_schema"
 version = "0.1.0"
 dependencies = [
  "http",
+ "mime",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1044,6 +1044,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "rede_schema"
+version = "0.1.0"
+dependencies = [
+ "http",
+]
+
+[[package]]
 name = "regex"
 version = "1.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,15 +1,11 @@
 [workspace]
-members = [
-    "bin",
-    "parser",
-    "placeholders"
-]
+members = ["bin", "parser", "placeholders", "schema"]
 resolver = "2"
 
 [workspace.package]
 edition = "2021"
 
-authors = [ "SotoEstevez <ricardo@sotoestevez.dev"]
+authors = ["SotoEstevez <ricardo@sotoestevez.dev"]
 homepage = "https://rede.sotoestevez.dev/"
 repository = "https://github.com/kriogenia/rede"
 license = "Apache-2.0 OR MIT"

--- a/schema/Cargo.toml
+++ b/schema/Cargo.toml
@@ -14,5 +14,9 @@ documentation = "https://docs.rs/rede_schema"
 keywords = ["rede", "schema", "request"]
 readme = "./README.md"
 
+[features]
+input_params = []
+
 [dependencies]
 http.workspace = true
+mime.workspace = true

--- a/schema/Cargo.toml
+++ b/schema/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "rede_schema"
+version = "0.1.0"
+edition.workspace = true
+
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+
+categories = ["network-programming"]
+description = "Exposes the request schema used by rede"
+documentation = "https://docs.rs/rede_schema"
+keywords = ["rede", "schema", "request"]
+readme = "./README.md"
+
+[dependencies]
+http.workspace = true

--- a/schema/README.md
+++ b/schema/README.md
@@ -1,0 +1,3 @@
+# Rede Schema
+
+TODO

--- a/schema/README.md
+++ b/schema/README.md
@@ -1,3 +1,3 @@
 # Rede Schema
 
-TODO
+This crate contains the structs used in the `rede` crate.

--- a/schema/src/body.rs
+++ b/schema/src/body.rs
@@ -32,8 +32,7 @@ impl Body {
     ///
     /// ```
     /// # fn main() {
-    /// # use thiserror::__private::AsDisplay;
-    /// # use rede_parser::body::Body;
+    /// # use rede_schema::body::Body;
     /// # let body = Body::Binary { path: "path".to_string(), mime: mime::APPLICATION_OCTET_STREAM};
     /// assert_eq!(body.mime().map(|m| m.to_string()), Some("application/octet-stream".to_string()));
     /// # }

--- a/schema/src/body.rs
+++ b/schema/src/body.rs
@@ -1,0 +1,122 @@
+use mime::Mime;
+use std::collections::HashMap;
+use std::fmt::{Display, Formatter};
+
+/// Body of the request, it contains all the currently supported options
+#[derive(Debug, Default, PartialEq)]
+pub enum Body {
+    /// The request does not have body (common for GET requests)
+    #[default]
+    None,
+    /// The body of the request is in text format. This body can be bundled with a Content-Type
+    /// like application/json to send JSONs with full meaning.
+    Raw { content: String, mime: Mime },
+    /// The body of the request contains a file located at the given path.
+    /// This body can be bundled with Content-Type headers like application/pdf.
+    Binary { path: String, mime: Mime },
+    /// The body is an HTTP form.
+    FormData(HashMap<String, FormDataValue>),
+    /// The body of the request is an HTTP form encoded in the URL.
+    XFormUrlEncoded(HashMap<String, String>),
+}
+
+/// Types of values for form data, can be text or binaries
+#[derive(Debug, PartialEq)]
+pub enum FormDataValue {
+    Text(String),
+    File(String),
+}
+
+impl Body {
+    /// Returns the MIME type associated with the body
+    ///
+    /// ```
+    /// # fn main() {
+    /// # use thiserror::__private::AsDisplay;
+    /// # use rede_parser::body::Body;
+    /// # let body = Body::Binary { path: "path".to_string(), mime: mime::APPLICATION_OCTET_STREAM};
+    /// assert_eq!(body.mime().map(|m| m.to_string()), Some("application/octet-stream".to_string()));
+    /// # }
+    /// ```
+    ///
+    #[must_use]
+    pub fn mime(&self) -> Option<&Mime> {
+        match self {
+            Body::None => None,
+            Body::Raw { mime, .. } | Body::Binary { mime, .. } => Some(mime),
+            Body::FormData(_) => Some(&mime::MULTIPART_FORM_DATA),
+            Body::XFormUrlEncoded(_) => Some(&mime::APPLICATION_WWW_FORM_URLENCODED),
+        }
+    }
+}
+
+impl Display for Body {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        use Body::{Binary, FormData, None, Raw, XFormUrlEncoded};
+        match self {
+            None => Ok(()),
+            Raw { content, .. } => write!(f, "{content}"),
+            Binary { path, .. } => write!(f, "@{path}"),
+            FormData(map) => {
+                for (k, v) in map {
+                    write!(f, "{k}: {v}")?;
+                }
+                Ok(())
+            }
+            XFormUrlEncoded(map) => {
+                for (k, v) in map {
+                    write!(f, "{k}: {v}")?;
+                }
+                Ok(())
+            }
+        }
+    }
+}
+
+impl Display for FormDataValue {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            FormDataValue::Text(value) => f.write_str(value),
+            FormDataValue::File(path) => write!(f, "@{path}"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    #[ignore]
+    fn display() {
+        let content = r#"
+        {
+          "key": "value"
+        }
+        "#
+        .to_string();
+        let body = Body::Raw {
+            content,
+            mime: mime::TEXT_PLAIN,
+        };
+        println!("{body}");
+
+        let body = Body::Binary {
+            path: "path/to/file".to_string(),
+            mime: mime::STAR_STAR,
+        };
+        println!("{body}");
+
+        let mut map = HashMap::new();
+        map.insert("text".to_string(), FormDataValue::Text("value".to_string()));
+        map.insert("file".to_string(), FormDataValue::File("path".to_string()));
+        let body = Body::FormData(map);
+        println!("{body}");
+
+        let mut map = HashMap::new();
+        map.insert("key".to_string(), "val".to_string());
+        map.insert("other".to_string(), "val".to_string());
+        let body = Body::XFormUrlEncoded(map);
+        println!("{body}");
+    }
+}

--- a/schema/src/input_param.rs
+++ b/schema/src/input_param.rs
@@ -1,0 +1,6 @@
+/// Contains the different properties that can be defined for an input parameter.
+#[derive(Debug, Default, PartialEq)]
+pub struct InputParam {
+    /// Hint to provide to the user when asking for the input
+    pub hint: Option<String>,
+}

--- a/schema/src/lib.rs
+++ b/schema/src/lib.rs
@@ -1,4 +1,8 @@
-//! TODO
+//! Library containing the structs used in the `rede` crate.
+//!
+//! # Features
+//!
+//! - `input_params`
 
 #![warn(clippy::pedantic)]
 
@@ -14,3 +18,33 @@ pub use body::Body;
 #[cfg(feature = "input_params")]
 #[doc(inline)]
 pub use input_param::InputParam;
+
+use std::collections::HashMap;
+
+use http::{HeaderMap, Method, Version};
+
+/// Representation of a rede HTTP request. Contains all the supported content by the current schema
+/// to allow the creation and dispatching of the HTTP request with the command-line interface.
+#[derive(Debug)]
+pub struct Request {
+    /// HTTP method of the request
+    pub method: Method,
+    /// URL of the request
+    pub url: String,
+    /// HTTP version of the request
+    pub http_version: Version,
+    /// Metadata of the request file
+    pub metadata: HashMap<String, String>,
+    /// Headers of the request
+    pub headers: HeaderMap,
+    /// Query parameters of the request
+    pub query_params: Vec<(String, String)>,
+    /// Body of the request
+    pub body: Body,
+    /// Variables to provide values for placeholders in the request
+    pub variables: HashMap<String, String>,
+
+    #[cfg(feature = "input_params")]
+    /// Keys of placeholders to ask the user for input
+    pub input_params: HashMap<String, InputParam>,
+}

--- a/schema/src/lib.rs
+++ b/schema/src/lib.rs
@@ -1,3 +1,9 @@
 //! TODO
 
 #![warn(clippy::pedantic)]
+
+/// Contains all the specific types used in the body
+pub mod body;
+
+#[doc(inline)]
+pub use body::Body;

--- a/schema/src/lib.rs
+++ b/schema/src/lib.rs
@@ -1,0 +1,3 @@
+//! TODO
+
+#![warn(clippy::pedantic)]

--- a/schema/src/lib.rs
+++ b/schema/src/lib.rs
@@ -5,5 +5,12 @@
 /// Contains all the specific types used in the body
 pub mod body;
 
+#[cfg(feature = "input_params")]
+mod input_param;
+
 #[doc(inline)]
 pub use body::Body;
+
+#[cfg(feature = "input_params")]
+#[doc(inline)]
+pub use input_param::InputParam;


### PR DESCRIPTION
Extracts the schema parts into a separate crate to ease dependencies.

- feat: create schema crate
- feat: set schema actions
- refactor: move body to schema crate
- refactor: move input params to schema crate
- refactor: move request to schema
