### PR TITLE
feat: --dry-run

### DIFF
--- a/bin/src/commands/example.rs
+++ b/bin/src/commands/example.rs
@@ -6,6 +6,8 @@ use std::io::Error;
 use tokio::fs::File;
 use tokio::io::AsyncWriteExt;
 
+use super::GlobalArgs;
+
 /// Generate an example request file to run
 #[derive(Debug, Args)]
 #[command(
@@ -16,7 +18,7 @@ pub struct Command;
 const EXAMPLE: &str = include_str!("../static/example.toml");
 
 impl Command {
-    pub async fn run(self) -> miette::Result<()> {
+    pub async fn run(self, _gargs: GlobalArgs) -> miette::Result<()> {
         let mut file = File::create("example.toml").await.map_err(map_err)?;
         let write = file.write_all(EXAMPLE.as_ref());
 

--- a/bin/src/commands/example.rs
+++ b/bin/src/commands/example.rs
@@ -18,10 +18,7 @@ pub struct Command;
 const EXAMPLE: &str = include_str!("../static/example.toml");
 
 impl Command {
-    pub async fn run(self, _gargs: GlobalArgs) -> miette::Result<()> {
-        let mut file = File::create("example.toml").await.map_err(map_err)?;
-        let write = file.write_all(EXAMPLE.as_ref());
-
+    pub async fn run(self, gargs: GlobalArgs) -> miette::Result<()> {
         let rede = style("rede").bold().cyan();
 
         standard!("Welcome to {rede}\n");
@@ -38,7 +35,16 @@ impl Command {
         standard!("```\n{EXAMPLE}\n```\n");
         standard!("Now just run: {}", style("rede run example").cyan());
 
-        write.await.map_err(map_err)?;
+        if !gargs.dry_run {
+            // feels kinda bad to not run this concurrently ith the printing but dry-run fucks it a bit
+            File::create("example.toml")
+                .await
+                .map_err(map_err)?
+                .write_all(EXAMPLE.as_ref())
+                .await
+                .map_err(map_err)?;
+        }
+
         Ok(())
     }
 }

--- a/bin/src/commands/run.rs
+++ b/bin/src/commands/run.rs
@@ -48,7 +48,7 @@ pub struct Command {
 }
 
 impl RedeCommand for Command {
-    async fn run(self, _gargs: GlobalArgs) -> miette::Result<()> {
+    async fn run(self, gargs: GlobalArgs) -> miette::Result<()> {
         info!("Launched rede run with {}", self.request);
 
         let content = input_to_string(&self.request)?;
@@ -56,6 +56,9 @@ impl RedeCommand for Command {
 
         let request = parse_request(&content).map_err(|e| ParsingError::parsing(content, e))?;
         self.print_request(&request);
+        if gargs.dry_run {
+            return Ok(());
+        }
 
         let client = Client::new((&self).try_into()?);
 

--- a/bin/src/commands/run.rs
+++ b/bin/src/commands/run.rs
@@ -11,6 +11,8 @@ use miette::{miette, LabeledSpan, Report};
 use rede_parser::parse_request;
 use std::time::Duration;
 
+use super::GlobalArgs;
+
 /// Executes the provided HTTP request
 #[derive(Debug, Args)]
 #[command(
@@ -46,7 +48,7 @@ pub struct Command {
 }
 
 impl RedeCommand for Command {
-    async fn run(self) -> miette::Result<()> {
+    async fn run(self, _gargs: GlobalArgs) -> miette::Result<()> {
         info!("Launched rede run with {}", self.request);
 
         let content = input_to_string(&self.request)?;

--- a/bin/tests/run.rs
+++ b/bin/tests/run.rs
@@ -58,6 +58,8 @@ test_request!(override_content_type -> contains(r#""content-type":"application/j
 test_request!(status_if_no_body<not_found> -> contains("404"));
 // todo -no-redirect, requires --verbose
 
+test_req!(dry_run, success, stdout, <get_simple> "--dry-run", "--verbose" -> contains("http://localhost:8080/api/hello").and(contains(r#"{"hello":"world"}"#).not()));
+
 test_error!(missing_file -> contains("invalid [REQUEST]").and(contains("No such file or directory")));
 test_error!(invalid_url -> contains("invalid url").and(contains("http://128.0.0.256")));
 test_error!(failed_connection -> contains("failed connection").and(contains("completelymadeupurl")));


### PR DESCRIPTION
Adds the `--dry-run` flag

﻿- feat: define dry-run and pass global args
- feat: run and example dry-run behavior
