### PR TITLE
feat: placeholders in example

### DIFF
--- a/bin/src/commands/run.rs
+++ b/bin/src/commands/run.rs
@@ -107,7 +107,6 @@ impl Command {
         };
 
         print_replacements(&values);
-        println!("{}", self.allow_unresolved);
         if values.is_all_resolved() || self.allow_unresolved {
             Renderer::new(&placeholders, values).render(request)
         } else {

--- a/bin/src/static/example.toml
+++ b/bin/src/static/example.toml
@@ -4,7 +4,14 @@ url = "https://dogapi.dog/api/v2/facts"
 
 [headers]
 Accept = "application/json"
-User-Agent = "rede/v0.1.0"
+User-Agent = "rede/v0.2.0"
 
 [query_params]
-limit = 1
+limit = "{{limit}}"
+
+[input_params]
+limit.hint = "Number of facts to retrieve"
+
+[variables]
+limit = 3
+


### PR DESCRIPTION
Adds placeholders (via variables and input params) to the request
created via `rede example`.
