### PR TITLE
feat: add body.json and body.xml support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "addr2line"
-version = "0.24.1"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5fb1d8e4442bd405fdfd1dacb42792696b0cf9cb15882e5d097b742a676d375"
+checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
 dependencies = [
  "gimli",
 ]
@@ -176,9 +176,9 @@ checksum = "428d9aa8fbc0670b7b8d6030a7fadd0f86151cae55e4dbbece15f3780a3dfaf3"
 
 [[package]]
 name = "cc"
-version = "1.1.24"
+version = "1.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812acba72f0a070b003d3697490d2b55b837230ae7c6c6497f05cc2ddbb8d938"
+checksum = "2e80e3b6a3ab07840e1cae9b0666a63970dc28e8ed5ffbcdacbfc760c281bfc1"
 dependencies = [
  "shlex",
 ]
@@ -191,9 +191,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.5.19"
+version = "4.5.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7be5744db7978a28d9df86a214130d106a89ce49644cbc4e3f0c22c3fba30615"
+checksum = "b97f376d85a664d5837dbae44bf546e6477a679ff6610010f17276f686d867e8"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -201,9 +201,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.19"
+version = "4.5.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5fbc17d3ef8278f55b282b2a2e75ae6f6c7d4bb70ed3d0382375104bfafdb4b"
+checksum = "19bc80abd44e4bed93ca373a0704ccbd1b710dc5749406201bb018272808dc54"
 dependencies = [
  "anstream",
  "anstyle",
@@ -401,30 +401,30 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
 ]
 
 [[package]]
 name = "futures-core"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
 name = "futures-io"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -433,21 +433,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
 
 [[package]]
 name = "futures-task"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
 name = "futures-util"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-core",
  "futures-io",
@@ -462,9 +462,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.31.0"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32085ea23f3234fc7846555e85283ba4de91e21016dc0455a16286d87a292d64"
+checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "h2"
@@ -658,9 +658,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.10.0"
+version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "187674a687eed5fe42285b40c6291f9a01517d415fad1c3cbc6a9f778af7fcd4"
+checksum = "ddc24109865250148c2e0f3d25d4f0f479571723792d3802153c60922a4fb708"
 
 [[package]]
 name = "is_ci"
@@ -682,9 +682,9 @@ checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "js-sys"
-version = "0.3.70"
+version = "0.3.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1868808506b929d7b0cfa8f75951347aa71bb21144b7791bae35d9bccfcfe37a"
+checksum = "0cb94a0ffd3f3ee755c20f7d8752f45cac88605a4dcf808abcff72873296ec7b"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -843,21 +843,18 @@ checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "object"
-version = "0.36.4"
+version = "0.36.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "084f1a5821ac4c651660a94a7153d27ac9d8a53736203f58b31945ded098070a"
+checksum = "aedf0a2d09c573ed1d8d85b30c119153926a2b36dce0ab28322c09a117a4683e"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.20.1"
+version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82881c4be219ab5faaf2ad5e5e5ecdff8c66bd7402ca3160975c93b24961afd1"
-dependencies = [
- "portable-atomic",
-]
+checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
 name = "openssl"
@@ -971,9 +968,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.86"
+version = "1.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
+checksum = "b3e4daa0dcf6feba26f985457cdf104d4b4256fc5a09547140f3631bb076b19a"
 dependencies = [
  "unicode-ident",
 ]
@@ -1204,9 +1201,9 @@ checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "schannel"
-version = "0.1.24"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9aaafd5a2b6e3d657ff009d82fbd630b6bd54dd4eb06f21693925cdf80f9b8b"
+checksum = "01227be5826fa0690321a2ba6c5cd57a19cf3f6a09e76973b58e61de6ab9d1c1"
 dependencies = [
  "windows-sys 0.59.0",
 ]
@@ -1670,9 +1667,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.93"
+version = "0.2.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a82edfc16a6c469f5f44dc7b571814045d60404b55a0ee849f9bcfa2e63dd9b5"
+checksum = "ef073ced962d62984fb38a36e5fdc1a2b23c9e0e1fa0689bb97afa4202ef6887"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1681,9 +1678,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.93"
+version = "0.2.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9de396da306523044d3302746f1208fa71d7532227f15e347e2d93e4145dd77b"
+checksum = "c4bfab14ef75323f4eb75fa52ee0a3fb59611977fd3240da19b2cf36ff85030e"
 dependencies = [
  "bumpalo",
  "log",
@@ -1696,9 +1693,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.43"
+version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61e9300f63a621e96ed275155c108eb6f843b6a26d053f122ab69724559dc8ed"
+checksum = "65471f79c1022ffa5291d33520cbbb53b7687b01c2f8e83b57d102eed7ed479d"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -1708,9 +1705,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.93"
+version = "0.2.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "585c4c91a46b072c92e908d99cb1dcdf95c5218eeb6f3bf1efa991ee7a68cccf"
+checksum = "a7bec9830f60924d9ceb3ef99d55c155be8afa76954edffbb5936ff4509474e7"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1718,9 +1715,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.93"
+version = "0.2.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
+checksum = "4c74f6e152a76a2ad448e223b0fc0b6b5747649c3d769cc6bf45737bf97d0ed6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1731,9 +1728,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.93"
+version = "0.2.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
+checksum = "a42f6c679374623f295a8623adfe63d9284091245c3504bde47c17a3ce2777d9"
 
 [[package]]
 name = "wasm-streams"
@@ -1750,9 +1747,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.70"
+version = "0.3.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26fdeaafd9bd129f65e7c031593c24d62186301e0c72c8978fa1678be7d532c0"
+checksum = "44188d185b5bdcae1052d08bcbcf9091a5524038d4572cc4f4f2bb9d5554ddd9"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -36,6 +36,10 @@ rede_parser = "0.2.2"
 rede_placeholders = "0.1.0"
 rede_schema = "0.2.0"
 
+# rede_parser = { path = "../parser" }            # local
+# rede_placeholders = { path = "../placeholders"} # local
+# rede_schema = { path = "../schema" }            # local
+
 http.workspace = true
 log.workspace = true
 miette = { workspace = true, features = ["fancy"] }

--- a/bin/tests/inputs/json_post.toml
+++ b/bin/tests/inputs/json_post.toml
@@ -1,0 +1,23 @@
+[http]
+method = "POST"
+url = "http://localhost:8080/api/post"
+
+[body]
+json = '''
+{
+  "characters": [
+    {
+      "code_name": "Solid Snake",
+      "real_name": "David"
+    },
+    {
+      "code_name": "Liquid Snake",
+      "real_name": "Eli" 
+    },
+    {
+      "code_name": "Gray Fox",
+      "real_name": "Frank Jaegar"
+    }
+  ]
+}
+'''

--- a/bin/tests/inputs/xml_post.toml
+++ b/bin/tests/inputs/xml_post.toml
@@ -1,0 +1,20 @@
+[http]
+method = "POST"
+url = "http://localhost:8080/api/post"
+
+[body]
+xml = '''
+<characters>
+
+    <character>
+        <name>Rhaegar Targaryen</name>
+        <title>The Last Dragon</title>
+    </character>
+
+    <character>
+        <name>Arthur Dayne</name>
+        <title>Sword of the Morning</title>
+    </character>
+
+</characters>
+'''

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -23,6 +23,7 @@ mime.workspace = true
 thiserror.workspace = true
 
 rede_schema = "0.2"
+# rede_schema = { path = "../schema" } # local 
 
 http-serde = "2.0"
 serde = { version = "1.0", features = ["derive"] }

--- a/parser/src/schema/body.rs
+++ b/parser/src/schema/body.rs
@@ -10,6 +10,10 @@ pub(crate) enum Body {
     None,
     #[serde(alias = "text")]
     Raw(String),
+    #[serde(alias = "json")]
+    Json(String),
+    #[serde(alias = "xml")]
+    Xml(String),
     #[serde(alias = "file")]
     Binary(String),
     #[serde(
@@ -41,6 +45,14 @@ impl From<Body> for SchemaBody {
             Body::Raw(content) => SchemaBody::Raw {
                 content,
                 mime: mime::TEXT_PLAIN_UTF_8,
+            },
+            Body::Json(content) => SchemaBody::Raw {
+                content,
+                mime: mime::APPLICATION_JSON,
+            },
+            Body::Xml(content) => SchemaBody::Raw {
+                content,
+                mime: mime::TEXT_XML,
             },
             Body::Binary(path) => SchemaBody::Binary {
                 path,

--- a/placeholders/Cargo.toml
+++ b/placeholders/Cargo.toml
@@ -19,6 +19,8 @@ input_params = ["rede_schema/input_params"]
 
 [dependencies]
 rede_schema = "0.2"
+# rede_schema = { path = "../schema" } # local
+
 http.workspace = true
 miette.workspace = true
 regex = "1.10.6"
@@ -26,3 +28,4 @@ regex = "1.10.6"
 [dev-dependencies]
 mime.workspace = true
 rede_parser = "0.2.2"
+# rede_parser = { path = "../parser/" } # local

--- a/placeholders/src/placeholders.rs
+++ b/placeholders/src/placeholders.rs
@@ -200,6 +200,9 @@ mod test {
                 .to_string(),
                 mime: mime::APPLICATION_JSON,
             },
+
+            #[cfg(feature = "input_params")]
+            input_params: BTreeMap::new(),
         };
 
         let placeholders = Placeholders::from(&request);

--- a/placeholders/src/renderer.rs
+++ b/placeholders/src/renderer.rs
@@ -99,6 +99,7 @@ impl<'ph> Renderer<'ph> {
             query_params,
             variables: request.variables,
             body,
+
             #[cfg(feature = "input_params")]
             input_params: request.input_params,
         })


### PR DESCRIPTION
- Expanded Body of parser/src/schema/body.rs for body.json and body.xml.

``` rust
pub(crate) enum Body {
    ...
    #[serde(alias = "json")]
    Json(String),
    #[serde(alias = "xml")]
    Xml(String),
    ...
}
```

``` rust
impl From<Body> for SchemaBody {
    fn from(value: Body) -> Self {
        match value {
           ...
            Body::Json(content) => SchemaBody::Raw {
                content,
                mime: mime::APPLICATION_JSON,
            },
            Body::Xml(content) => SchemaBody::Raw {
                content,
                mime: mime::TEXT_XML,
            },
            ...
    }
}
```
- Also added `bin/tests/inputs/json_post.toml` and `bin/tests/inputs/xml_post.toml` and tested them on a simple server.

- Also added these lines in bin/Cargo.toml, as it pulls the crates from crates.io and could not accommodate the local changes. These lines can be removed.

``` toml
[dependencies]
rede_parser = "0.2.2"
rede_placeholders = "0.1.0"
rede_schema = "0.2.0"

# rede_parser = { path = "../parser" }            # local
# rede_placeholders = { path = "../placeholders"} # local
# rede_schema = { path = "../schema" }            # local
```